### PR TITLE
ci: add permissions: contents: read to tiobe

### DIFF
--- a/.github/workflows/tiobe.yaml
+++ b/.github/workflows/tiobe.yaml
@@ -8,6 +8,9 @@ on:
   schedule:
     - cron: '0 7 1 * *'
 
+permissions:
+  contents: read
+
 jobs:
   TICS:
     runs-on: [ self-hosted, amd64, tiobe, noble ]


### PR DESCRIPTION
Adds a workflow-level `permissions: contents: read` block to `.github/workflows/tiobe.yaml`.

The TIOBE quality check workflow only reads the repository contents; it does not push, comment, or release. Declaring the minimum scope means a compromised third-party action cannot abuse the run's token to escalate. This is the pattern GitHub recommends in their [token hardening guide](https://docs.github.com/en/actions/security-guides/automatic-token-authentication#modifying-the-permissions-for-the-github_token) and is what OpenSSF Scorecard's `Token-Permissions` check looks for.

A recent reminder of why this matters: tj-actions/changed-files compromise in March 2025 (CVE-2025-30066).

Verified with `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/tiobe.yaml'))"`.
