### PR TITLE
Enhance CLI

### DIFF
--- a/.github/prompts/opsx-apply.prompt.md
+++ b/.github/prompts/opsx-apply.prompt.md
@@ -1,0 +1,152 @@
+---
+description: Implement tasks from an OpenSpec change (Experimental)
+---
+
+Implement tasks from an OpenSpec change.
+
+**Input**: Optionally specify a change name (e.g., `/opsx:apply add-auth`). If omitted, check if it can be inferred from conversation context. If vague or ambiguous you MUST prompt for available changes.
+
+**Steps**
+
+1. **Select the change**
+
+   If a name is provided, use it. Otherwise:
+   - Infer from conversation context if the user mentioned a change
+   - Auto-select if only one active change exists
+   - If ambiguous, run `openspec list --json` to get available changes and use the **AskUserQuestion tool** to let the user select
+
+   Always announce: "Using change: <name>" and how to override (e.g., `/opsx:apply <other>`).
+
+2. **Check status to understand the schema**
+   ```bash
+   openspec status --change "<name>" --json
+   ```
+   Parse the JSON to understand:
+   - `schemaName`: The workflow being used (e.g., "spec-driven")
+   - `planningHome`, `changeRoot`, and `actionContext`: planning scope and edit constraints
+   - Which artifact contains the tasks (typically "tasks" for spec-driven, check status for others)
+
+3. **Get apply instructions**
+
+   ```bash
+   openspec instructions apply --change "<name>" --json
+   ```
+
+   This returns:
+   - `contextFiles`: artifact ID -> array of concrete file paths (varies by schema)
+   - Progress (total, complete, remaining)
+   - Task list with status
+   - Dynamic instruction based on current state
+
+   **Handle states:**
+   - If `state: "blocked"` (missing artifacts): show message, suggest using `/opsx:continue`
+   - If `state: "all_done"`: congratulate, suggest archive
+   - Otherwise: proceed to implementation
+
+   **Workspace guard:** If status JSON reports `actionContext.mode: "workspace-planning"` and `allowedEditRoots` is empty, explain that full workspace apply is not supported in this slice. Treat linked repos and folders as read-only context, ask the user to select an affected area through an explicit implementation workflow, and STOP before editing files.
+
+4. **Read context files**
+
+   Read every file path listed under `contextFiles` from the apply instructions output.
+   The files depend on the schema being used:
+   - **spec-driven**: proposal, specs, design, tasks
+   - Other schemas: follow the contextFiles from CLI output
+
+5. **Show current progress**
+
+   Display:
+   - Schema being used
+   - Progress: "N/M tasks complete"
+   - Remaining tasks overview
+   - Dynamic instruction from CLI
+
+6. **Implement tasks (loop until done or blocked)**
+
+   For each pending task:
+   - Show which task is being worked on
+   - Make the code changes required
+   - Keep changes minimal and focused
+   - Mark task complete in the tasks file: `- [ ]` → `- [x]`
+   - Continue to next task
+
+   **Pause if:**
+   - Task is unclear → ask for clarification
+   - Implementation reveals a design issue → suggest updating artifacts
+   - Error or blocker encountered → report and wait for guidance
+   - User interrupts
+
+7. **On completion or pause, show status**
+
+   Display:
+   - Tasks completed this session
+   - Overall progress: "N/M tasks complete"
+   - If all done: suggest archive
+   - If paused: explain why and wait for guidance
+
+**Output During Implementation**
+
+```
+## Implementing: <change-name> (schema: <schema-name>)
+
+Working on task 3/7: <task description>
+[...implementation happening...]
+✓ Task complete
+
+Working on task 4/7: <task description>
+[...implementation happening...]
+✓ Task complete
+```
+
+**Output On Completion**
+
+```
+## Implementation Complete
+
+**Change:** <change-name>
+**Schema:** <schema-name>
+**Progress:** 7/7 tasks complete ✓
+
+### Completed This Session
+- [x] Task 1
+- [x] Task 2
+...
+
+All tasks complete! You can archive this change with `/opsx:archive`.
+```
+
+**Output On Pause (Issue Encountered)**
+
+```
+## Implementation Paused
+
+**Change:** <change-name>
+**Schema:** <schema-name>
+**Progress:** 4/7 tasks complete
+
+### Issue Encountered
+<description of the issue>
+
+**Options:**
+1. <option 1>
+2. <option 2>
+3. Other approach
+
+What would you like to do?
+```
+
+**Guardrails**
+- Keep going through tasks until done or blocked
+- Always read context files before starting (from the apply instructions output)
+- If task is ambiguous, pause and ask before implementing
+- If implementation reveals issues, pause and suggest artifact updates
+- Keep code changes minimal and scoped to each task
+- Update task checkbox immediately after completing each task
+- Pause on errors, blockers, or unclear requirements - don't guess
+- Use contextFiles from CLI output, don't assume specific file names
+
+**Fluid Workflow Integration**
+
+This skill supports the "actions on a change" model:
+
+- **Can be invoked anytime**: Before all artifacts are done (if tasks exist), after partial implementation, interleaved with other actions
+- **Allows artifact updates**: If implementation reveals design issues, suggest updating artifacts - not phase-locked, work fluidly

--- a/.github/prompts/opsx-archive.prompt.md
+++ b/.github/prompts/opsx-archive.prompt.md
@@ -1,0 +1,157 @@
+---
+description: Archive a completed change in the experimental workflow
+---
+
+Archive a completed change in the experimental workflow.
+
+**Input**: Optionally specify a change name after `/opsx:archive` (e.g., `/opsx:archive add-auth`). If omitted, check if it can be inferred from conversation context. If vague or ambiguous you MUST prompt for available changes.
+
+**Steps**
+
+1. **If no change name provided, prompt for selection**
+
+   Run `openspec list --json` to get available changes. Use the **AskUserQuestion tool** to let the user select.
+
+   Show only active changes (not already archived).
+   Include the schema used for each change if available.
+
+   **IMPORTANT**: Do NOT guess or auto-select a change. Always let the user choose.
+
+2. **Check artifact completion status**
+
+   Run `openspec status --change "<name>" --json` to check artifact completion.
+
+   Parse the JSON to understand:
+   - `schemaName`: The workflow being used
+   - `planningHome`, `changeRoot`, `artifactPaths`, and `actionContext`: path and scope context
+   - `artifacts`: List of artifacts with their status (`done` or other)
+
+   If status reports `actionContext.mode: "workspace-planning"`, explain that workspace archive is not supported in this slice and STOP. Do not move workspace changes into repo-local archives or edit linked repos.
+
+   **If any artifacts are not `done`:**
+   - Display warning listing incomplete artifacts
+   - Prompt user for confirmation to continue
+   - Proceed if user confirms
+
+3. **Check task completion status**
+
+   Read the tasks file (typically `tasks.md`) to check for incomplete tasks.
+
+   Count tasks marked with `- [ ]` (incomplete) vs `- [x]` (complete).
+
+   **If incomplete tasks found:**
+   - Display warning showing count of incomplete tasks
+   - Prompt user for confirmation to continue
+   - Proceed if user confirms
+
+   **If no tasks file exists:** Proceed without task-related warning.
+
+4. **Assess delta spec sync state**
+
+   Use `artifactPaths.specs.existingOutputPaths` from status JSON to check for delta specs. If none exist, proceed without sync prompt.
+
+   **If delta specs exist:**
+   - Compare each delta spec with its corresponding main spec at `openspec/specs/<capability>/spec.md`
+   - Determine what changes would be applied (adds, modifications, removals, renames)
+   - Show a combined summary before prompting
+
+   **Prompt options:**
+   - If changes needed: "Sync now (recommended)", "Archive without syncing"
+   - If already synced: "Archive now", "Sync anyway", "Cancel"
+
+   If user chooses sync, use Task tool (subagent_type: "general-purpose", prompt: "Use Skill tool to invoke openspec-sync-specs for change '<name>'. Delta spec analysis: <include the analyzed delta spec summary>"). Proceed to archive regardless of choice.
+
+5. **Perform the archive**
+
+   Create an `archive` directory under `planningHome.changesDir` if it doesn't exist:
+   ```bash
+   mkdir -p "<planningHome.changesDir>/archive"
+   ```
+
+   Generate target name using current date: `YYYY-MM-DD-<change-name>`
+
+   **Check if target already exists:**
+   - If yes: Fail with error, suggest renaming existing archive or using different date
+   - If no: Move `changeRoot` to the archive directory
+
+   ```bash
+   mv "<changeRoot>" "<planningHome.changesDir>/archive/YYYY-MM-DD-<name>"
+   ```
+
+6. **Display summary**
+
+   Show archive completion summary including:
+   - Change name
+   - Schema that was used
+   - Archive location
+   - Spec sync status (synced / sync skipped / no delta specs)
+   - Note about any warnings (incomplete artifacts/tasks)
+
+**Output On Success**
+
+```
+## Archive Complete
+
+**Change:** <change-name>
+**Schema:** <schema-name>
+**Archived to:** the archive path derived from `planningHome.changesDir`/YYYY-MM-DD-<name>/
+**Specs:** ✓ Synced to main specs
+
+All artifacts complete. All tasks complete.
+```
+
+**Output On Success (No Delta Specs)**
+
+```
+## Archive Complete
+
+**Change:** <change-name>
+**Schema:** <schema-name>
+**Archived to:** the archive path derived from `planningHome.changesDir`/YYYY-MM-DD-<name>/
+**Specs:** No delta specs
+
+All artifacts complete. All tasks complete.
+```
+
+**Output On Success With Warnings**
+
+```
+## Archive Complete (with warnings)
+
+**Change:** <change-name>
+**Schema:** <schema-name>
+**Archived to:** the archive path derived from `planningHome.changesDir`/YYYY-MM-DD-<name>/
+**Specs:** Sync skipped (user chose to skip)
+
+**Warnings:**
+- Archived with 2 incomplete artifacts
+- Archived with 3 incomplete tasks
+- Delta spec sync was skipped (user chose to skip)
+
+Review the archive if this was not intentional.
+```
+
+**Output On Error (Archive Exists)**
+
+```
+## Archive Failed
+
+**Change:** <change-name>
+**Target:** the archive path derived from `planningHome.changesDir`/YYYY-MM-DD-<name>/
+
+Target archive directory already exists.
+
+**Options:**
+1. Rename the existing archive
+2. Delete the existing archive if it's a duplicate
+3. Wait until a different date to archive
+```
+
+**Guardrails**
+- Always prompt for change selection if not provided
+- Use artifact graph (openspec status --json) for completion checking
+- Don't block archive on warnings - just inform and confirm
+- Preserve .openspec.yaml when moving to archive (it moves with the directory)
+- Show clear summary of what happened
+- If sync is requested, use the Skill tool to invoke `openspec-sync-specs` (agent-driven)
+- If delta specs exist, always run the sync assessment and show the combined summary before prompting

--- a/.github/prompts/opsx-explore.prompt.md
+++ b/.github/prompts/opsx-explore.prompt.md
@@ -1,0 +1,169 @@
+---
+description: Enter explore mode - think through ideas, investigate problems, clarify requirements
+---
+
+Enter explore mode. Think deeply. Visualize freely. Follow the conversation wherever it goes.
+
+**IMPORTANT: Explore mode is for thinking, not implementing.** You may read files, search code, and investigate the codebase, but you must NEVER write code or implement features. If the user asks you to implement something, remind them to exit explore mode first and create a change proposal. You MAY create OpenSpec artifacts (proposals, designs, specs) if the user asks—that's capturing thinking, not implementing.
+
+**This is a stance, not a workflow.** There are no fixed steps, no required sequence, no mandatory outputs. You're a thinking partner helping the user explore.
+
+**Input**: The argument after `/opsx:explore` is whatever the user wants to think about. Could be:
+- A vague idea: "real-time collaboration"
+- A specific problem: "the auth system is getting unwieldy"
+- A change name: "add-dark-mode" (to explore in context of that change)
+- A comparison: "postgres vs sqlite for this"
+- Nothing (just enter explore mode)
+
+---
+
+## The Stance
+
+- **Curious, not prescriptive** - Ask questions that emerge naturally, don't follow a script
+- **Open threads, not interrogations** - Surface multiple interesting directions and let the user follow what resonates. Don't funnel them through a single path of questions.
+- **Visual** - Use ASCII diagrams liberally when they'd help clarify thinking
+- **Adaptive** - Follow interesting threads, pivot when new information emerges
+- **Patient** - Don't rush to conclusions, let the shape of the problem emerge
+- **Grounded** - Explore the actual codebase when relevant, don't just theorize
+
+---
+
+## What You Might Do
+
+Depending on what the user brings, you might:
+
+**Explore the problem space**
+- Ask clarifying questions that emerge from what they said
+- Challenge assumptions
+- Reframe the problem
+- Find analogies
+
+**Investigate the codebase**
+- Map existing architecture relevant to the discussion
+- Find integration points
+- Identify patterns already in use
+- Surface hidden complexity
+
+**Compare options**
+- Brainstorm multiple approaches
+- Build comparison tables
+- Sketch tradeoffs
+- Recommend a path (if asked)
+
+**Visualize**
+```
+┌─────────────────────────────────────────┐
+│     Use ASCII diagrams liberally        │
+├─────────────────────────────────────────┤
+│                                         │
+│      ┌────────┐         ┌────────┐      │
+│      │ State  │────────▶│ State  │      │
+│      │   A    │         │   B    │      │
+│      └────────┘         └────────┘      │
+│                                         │
+│   System diagrams, state machines,      │
+│   data flows, architecture sketches,    │
+│   dependency graphs, comparison tables  │
+│                                         │
+└─────────────────────────────────────────┘
+```
+
+**Surface risks and unknowns**
+- Identify what could go wrong
+- Find gaps in understanding
+- Suggest spikes or investigations
+
+---
+
+## OpenSpec Awareness
+
+You have full context of the OpenSpec system. Use it naturally, don't force it.
+
+### Check for context
+
+At the start, quickly check what exists:
+```bash
+openspec list --json
+```
+
+This tells you:
+- If there are active changes
+- Their names, schemas, and status
+- What the user might be working on
+
+If the user mentioned a specific change name, read its artifacts for context.
+
+### When no change exists
+
+Think freely. When insights crystallize, you might offer:
+
+- "This feels solid enough to start a change. Want me to create a proposal?"
+- Or keep exploring - no pressure to formalize
+
+### When a change exists
+
+If the user mentions a change or you detect one is relevant:
+
+1. **Resolve and read existing artifacts for context**
+   - Run `openspec status --change "<name>" --json`.
+   - Use `changeRoot`, `artifactPaths`, and `actionContext` from the status JSON.
+   - Read existing files from `artifactPaths.<artifact>.existingOutputPaths`.
+
+2. **Reference them naturally in conversation**
+   - "Your design mentions using Redis, but we just realized SQLite fits better..."
+   - "The proposal scopes this to premium users, but we're now thinking everyone..."
+
+3. **Offer to capture when decisions are made**
+
+    | Insight Type               | Where to Capture               |
+    |----------------------------|--------------------------------|
+    | New requirement discovered | `specs/<capability>/spec.md` |
+    | Requirement changed        | `specs/<capability>/spec.md` |
+    | Design decision made       | `design.md`                  |
+    | Scope changed              | `proposal.md`                |
+    | New work identified        | `tasks.md`                   |
+    | Assumption invalidated     | Relevant artifact              |
+
+   Example offers:
+   - "That's a design decision. Capture it in design.md?"
+   - "This is a new requirement. Add it to specs?"
+   - "This changes scope. Update the proposal?"
+
+4. **The user decides** - Offer and move on. Don't pressure. Don't auto-capture.
+
+---
+
+## What You Don't Have To Do
+
+- Follow a script
+- Ask the same questions every time
+- Produce a specific artifact
+- Reach a conclusion
+- Stay on topic if a tangent is valuable
+- Be brief (this is thinking time)
+
+---
+
+## Ending Discovery
+
+There's no required ending. Discovery might:
+
+- **Flow into a proposal**: "Ready to start? I can create a change proposal."
+- **Result in artifact updates**: "Updated design.md with these decisions"
+- **Just provide clarity**: User has what they need, moves on
+- **Continue later**: "We can pick this up anytime"
+
+When things crystallize, you might offer a summary - but it's optional. Sometimes the thinking IS the value.
+
+---
+
+## Guardrails
+
+- **Don't implement** - Never write code or implement features. Creating OpenSpec artifacts is fine, writing application code is not.
+- **Don't fake understanding** - If something is unclear, dig deeper
+- **Don't rush** - Discovery is thinking time, not task time
+- **Don't force structure** - Let patterns emerge naturally
+- **Don't auto-capture** - Offer to save insights, don't just do it
+- **Do visualize** - A good diagram is worth many paragraphs
+- **Do explore the codebase** - Ground discussions in reality
+- **Do question assumptions** - Including the user's and your own

--- a/.github/prompts/opsx-propose.prompt.md
+++ b/.github/prompts/opsx-propose.prompt.md
@@ -1,0 +1,104 @@
+---
+description: Propose a new change - create it and generate all artifacts in one step
+---
+
+Propose a new change - create the change and generate all artifacts in one step.
+
+I'll create a change with artifacts:
+- proposal.md (what & why)
+- design.md (how)
+- tasks.md (implementation steps)
+
+When ready to implement, run /opsx:apply
+
+---
+
+**Input**: The argument after `/opsx:propose` is the change name (kebab-case), OR a description of what the user wants to build.
+
+**Steps**
+
+1. **If no input provided, ask what they want to build**
+
+   Use the **AskUserQuestion tool** (open-ended, no preset options) to ask:
+   > "What change do you want to work on? Describe what you want to build or fix."
+
+   From their description, derive a kebab-case name (e.g., "add user authentication" → `add-user-auth`).
+
+   **IMPORTANT**: Do NOT proceed without understanding what the user wants to build.
+
+2. **Create the change directory**
+   ```bash
+   openspec new change "<name>"
+   ```
+   This creates a scaffolded change in the planning home resolved by the CLI with `.openspec.yaml`.
+
+3. **Get the artifact build order**
+   ```bash
+   openspec status --change "<name>" --json
+   ```
+   Parse the JSON to get:
+   - `applyRequires`: array of artifact IDs needed before implementation (e.g., `["tasks"]`)
+   - `artifacts`: list of all artifacts with their status and dependencies
+   - `planningHome`, `changeRoot`, `artifactPaths`, and `actionContext`: path and scope context. Use these instead of assuming repo-local paths.
+
+4. **Create artifacts in sequence until apply-ready**
+
+   Use the **TodoWrite tool** to track progress through the artifacts.
+
+   Loop through artifacts in dependency order (artifacts with no pending dependencies first):
+
+   a. **For each artifact that is `ready` (dependencies satisfied)**:
+      - Get instructions:
+        ```bash
+        openspec instructions <artifact-id> --change "<name>" --json
+        ```
+      - The instructions JSON includes:
+        - `context`: Project background (constraints for you - do NOT include in output)
+        - `rules`: Artifact-specific rules (constraints for you - do NOT include in output)
+        - `template`: The structure to use for your output file
+        - `instruction`: Schema-specific guidance for this artifact type
+        - `resolvedOutputPath`: Resolved path or pattern to write the artifact
+        - `dependencies`: Completed artifacts to read for context
+      - Read any completed dependency files for context
+      - Create the artifact file using `template` as the structure and write it to `resolvedOutputPath`
+      - Apply `context` and `rules` as constraints - but do NOT copy them into the file
+      - Show brief progress: "Created <artifact-id>"
+
+   b. **Continue until all `applyRequires` artifacts are complete**
+      - After creating each artifact, re-run `openspec status --change "<name>" --json`
+      - Check if every artifact ID in `applyRequires` has `status: "done"` in the artifacts array
+      - Stop when all `applyRequires` artifacts are done
+
+   c. **If an artifact requires user input** (unclear context):
+      - Use **AskUserQuestion tool** to clarify
+      - Then continue with creation
+
+5. **Show final status**
+   ```bash
+   openspec status --change "<name>"
+   ```
+
+**Output**
+
+After completing all artifacts, summarize:
+- Change name and location
+- List of artifacts created with brief descriptions
+- What's ready: "All artifacts created! Ready for implementation."
+- Prompt: "Run `/opsx:apply` to start implementing."
+
+**Artifact Creation Guidelines**
+
+- Follow the `instruction` field from `openspec instructions` for each artifact type
+- The schema defines what each artifact should contain - follow it
+- Read dependency artifacts for context before creating new ones
+- Use `template` as the structure for your output file - fill in its sections
+- **IMPORTANT**: `context` and `rules` are constraints for YOU, not content for the file
+  - Do NOT copy `<context>`, `<rules>`, `<project_context>` blocks into the artifact
+  - These guide what you write, but should never appear in the output
+
+**Guardrails**
+- Create ALL artifacts needed for implementation (as defined by schema's `apply.requires`)
+- Always read dependency artifacts before creating a new one
+- If context is critically unclear, ask the user - but prefer making reasonable decisions to keep momentum
+- If a change with that name already exists, ask if user wants to continue it or create a new one
+- Verify each artifact file exists after writing before proceeding to next

--- a/.github/skills/openspec-apply-change/SKILL.md
+++ b/.github/skills/openspec-apply-change/SKILL.md
@@ -1,0 +1,159 @@
+---
+name: openspec-apply-change
+description: Implement tasks from an OpenSpec change. Use when the user wants to start implementing, continue implementation, or work through tasks.
+license: MIT
+compatibility: Requires openspec CLI.
+metadata:
+  author: openspec
+  version: "1.0"
+  generatedBy: "1.4.1"
+---
+
+Implement tasks from an OpenSpec change.
+
+**Input**: Optionally specify a change name. If omitted, check if it can be inferred from conversation context. If vague or ambiguous you MUST prompt for available changes.
+
+**Steps**
+
+1. **Select the change**
+
+   If a name is provided, use it. Otherwise:
+   - Infer from conversation context if the user mentioned a change
+   - Auto-select if only one active change exists
+   - If ambiguous, run `openspec list --json` to get available changes and use the **AskUserQuestion tool** to let the user select
+
+   Always announce: "Using change: <name>" and how to override (e.g., `/opsx:apply <other>`).
+
+2. **Check status to understand the schema**
+   ```bash
+   openspec status --change "<name>" --json
+   ```
+   Parse the JSON to understand:
+   - `schemaName`: The workflow being used (e.g., "spec-driven")
+   - `planningHome`, `changeRoot`, and `actionContext`: planning scope and edit constraints
+   - Which artifact contains the tasks (typically "tasks" for spec-driven, check status for others)
+
+3. **Get apply instructions**
+
+   ```bash
+   openspec instructions apply --change "<name>" --json
+   ```
+
+   This returns:
+   - `contextFiles`: artifact ID -> array of concrete file paths (varies by schema - could be proposal/specs/design/tasks or spec/tests/implementation/docs)
+   - Progress (total, complete, remaining)
+   - Task list with status
+   - Dynamic instruction based on current state
+
+   **Handle states:**
+   - If `state: "blocked"` (missing artifacts): show message, suggest using openspec-continue-change
+   - If `state: "all_done"`: congratulate, suggest archive
+   - Otherwise: proceed to implementation
+
+   **Workspace guard:** If status JSON reports `actionContext.mode: "workspace-planning"` and `allowedEditRoots` is empty, explain that full workspace apply is not supported in this slice. Treat linked repos and folders as read-only context, ask the user to select an affected area through an explicit implementation workflow, and STOP before editing files.
+
+4. **Read context files**
+
+   Read every file path listed under `contextFiles` from the apply instructions output.
+   The files depend on the schema being used:
+   - **spec-driven**: proposal, specs, design, tasks
+   - Other schemas: follow the contextFiles from CLI output
+
+5. **Show current progress**
+
+   Display:
+   - Schema being used
+   - Progress: "N/M tasks complete"
+   - Remaining tasks overview
+   - Dynamic instruction from CLI
+
+6. **Implement tasks (loop until done or blocked)**
+
+   For each pending task:
+   - Show which task is being worked on
+   - Make the code changes required
+   - Keep changes minimal and focused
+   - Mark task complete in the tasks file: `- [ ]` → `- [x]`
+   - Continue to next task
+
+   **Pause if:**
+   - Task is unclear → ask for clarification
+   - Implementation reveals a design issue → suggest updating artifacts
+   - Error or blocker encountered → report and wait for guidance
+   - User interrupts
+
+7. **On completion or pause, show status**
+
+   Display:
+   - Tasks completed this session
+   - Overall progress: "N/M tasks complete"
+   - If all done: suggest archive
+   - If paused: explain why and wait for guidance
+
+**Output During Implementation**
+
+```
+## Implementing: <change-name> (schema: <schema-name>)
+
+Working on task 3/7: <task description>
+[...implementation happening...]
+✓ Task complete
+
+Working on task 4/7: <task description>
+[...implementation happening...]
+✓ Task complete
+```
+
+**Output On Completion**
+
+```
+## Implementation Complete
+
+**Change:** <change-name>
+**Schema:** <schema-name>
+**Progress:** 7/7 tasks complete ✓
+
+### Completed This Session
+- [x] Task 1
+- [x] Task 2
+...
+
+All tasks complete! Ready to archive this change.
+```
+
+**Output On Pause (Issue Encountered)**
+
+```
+## Implementation Paused
+
+**Change:** <change-name>
+**Schema:** <schema-name>
+**Progress:** 4/7 tasks complete
+
+### Issue Encountered
+<description of the issue>
+
+**Options:**
+1. <option 1>
+2. <option 2>
+3. Other approach
+
+What would you like to do?
+```
+
+**Guardrails**
+- Keep going through tasks until done or blocked
+- Always read context files before starting (from the apply instructions output)
+- If task is ambiguous, pause and ask before implementing
+- If implementation reveals issues, pause and suggest artifact updates
+- Keep code changes minimal and scoped to each task
+- Update task checkbox immediately after completing each task
+- Pause on errors, blockers, or unclear requirements - don't guess
+- Use contextFiles from CLI output, don't assume specific file names
+
+**Fluid Workflow Integration**
+
+This skill supports the "actions on a change" model:
+
+- **Can be invoked anytime**: Before all artifacts are done (if tasks exist), after partial implementation, interleaved with other actions
+- **Allows artifact updates**: If implementation reveals design issues, suggest updating artifacts - not phase-locked, work fluidly

--- a/.github/skills/openspec-archive-change/SKILL.md
+++ b/.github/skills/openspec-archive-change/SKILL.md
@@ -1,0 +1,117 @@
+---
+name: openspec-archive-change
+description: Archive a completed change in the experimental workflow. Use when the user wants to finalize and archive a change after implementation is complete.
+license: MIT
+compatibility: Requires openspec CLI.
+metadata:
+  author: openspec
+  version: "1.0"
+  generatedBy: "1.4.1"
+---
+
+Archive a completed change in the experimental workflow.
+
+**Input**: Optionally specify a change name. If omitted, check if it can be inferred from conversation context. If vague or ambiguous you MUST prompt for available changes.
+
+**Steps**
+
+1. **If no change name provided, prompt for selection**
+
+   Run `openspec list --json` to get available changes. Use the **AskUserQuestion tool** to let the user select.
+
+   Show only active changes (not already archived).
+   Include the schema used for each change if available.
+
+   **IMPORTANT**: Do NOT guess or auto-select a change. Always let the user choose.
+
+2. **Check artifact completion status**
+
+   Run `openspec status --change "<name>" --json` to check artifact completion.
+
+   Parse the JSON to understand:
+   - `schemaName`: The workflow being used
+   - `planningHome`, `changeRoot`, `artifactPaths`, and `actionContext`: path and scope context
+   - `artifacts`: List of artifacts with their status (`done` or other)
+
+   If status reports `actionContext.mode: "workspace-planning"`, explain that workspace archive is not supported in this slice and STOP. Do not move workspace changes into repo-local archives or edit linked repos.
+
+   **If any artifacts are not `done`:**
+   - Display warning listing incomplete artifacts
+   - Use **AskUserQuestion tool** to confirm user wants to proceed
+   - Proceed if user confirms
+
+3. **Check task completion status**
+
+   Read the tasks file (typically `tasks.md`) to check for incomplete tasks.
+
+   Count tasks marked with `- [ ]` (incomplete) vs `- [x]` (complete).
+
+   **If incomplete tasks found:**
+   - Display warning showing count of incomplete tasks
+   - Use **AskUserQuestion tool** to confirm user wants to proceed
+   - Proceed if user confirms
+
+   **If no tasks file exists:** Proceed without task-related warning.
+
+4. **Assess delta spec sync state**
+
+   Use `artifactPaths.specs.existingOutputPaths` from status JSON to check for delta specs. If none exist, proceed without sync prompt.
+
+   **If delta specs exist:**
+   - Compare each delta spec with its corresponding main spec at `openspec/specs/<capability>/spec.md`
+   - Determine what changes would be applied (adds, modifications, removals, renames)
+   - Show a combined summary before prompting
+
+   **Prompt options:**
+   - If changes needed: "Sync now (recommended)", "Archive without syncing"
+   - If already synced: "Archive now", "Sync anyway", "Cancel"
+
+   If user chooses sync, use Task tool (subagent_type: "general-purpose", prompt: "Use Skill tool to invoke openspec-sync-specs for change '<name>'. Delta spec analysis: <include the analyzed delta spec summary>"). Proceed to archive regardless of choice.
+
+5. **Perform the archive**
+
+   Create an `archive` directory under `planningHome.changesDir` if it doesn't exist:
+   ```bash
+   mkdir -p "<planningHome.changesDir>/archive"
+   ```
+
+   Generate target name using current date: `YYYY-MM-DD-<change-name>`
+
+   **Check if target already exists:**
+   - If yes: Fail with error, suggest renaming existing archive or using different date
+   - If no: Move `changeRoot` to the archive directory
+
+   ```bash
+   mv "<changeRoot>" "<planningHome.changesDir>/archive/YYYY-MM-DD-<name>"
+   ```
+
+6. **Display summary**
+
+   Show archive completion summary including:
+   - Change name
+   - Schema that was used
+   - Archive location
+   - Whether specs were synced (if applicable)
+   - Note about any warnings (incomplete artifacts/tasks)
+
+**Output On Success**
+
+```
+## Archive Complete
+
+**Change:** <change-name>
+**Schema:** <schema-name>
+**Archived to:** the archive path derived from `planningHome.changesDir`/YYYY-MM-DD-<name>/
+**Specs:** ✓ Synced to main specs (or "No delta specs" or "Sync skipped")
+
+All artifacts complete. All tasks complete.
+```
+
+**Guardrails**
+- Always prompt for change selection if not provided
+- Use artifact graph (openspec status --json) for completion checking
+- Don't block archive on warnings - just inform and confirm
+- Preserve .openspec.yaml when moving to archive (it moves with the directory)
+- Show clear summary of what happened
+- If sync is requested, use openspec-sync-specs approach (agent-driven)
+- If delta specs exist, always run the sync assessment and show the combined summary before prompting

--- a/.github/skills/openspec-explore/SKILL.md
+++ b/.github/skills/openspec-explore/SKILL.md
@@ -1,0 +1,287 @@
+---
+name: openspec-explore
+description: Enter explore mode - a thinking partner for exploring ideas, investigating problems, and clarifying requirements. Use when the user wants to think through something before or during a change.
+license: MIT
+compatibility: Requires openspec CLI.
+metadata:
+  author: openspec
+  version: "1.0"
+  generatedBy: "1.4.1"
+---
+
+Enter explore mode. Think deeply. Visualize freely. Follow the conversation wherever it goes.
+
+**IMPORTANT: Explore mode is for thinking, not implementing.** You may read files, search code, and investigate the codebase, but you must NEVER write code or implement features. If the user asks you to implement something, remind them to exit explore mode first and create a change proposal. You MAY create OpenSpec artifacts (proposals, designs, specs) if the user asks—that's capturing thinking, not implementing.
+
+**This is a stance, not a workflow.** There are no fixed steps, no required sequence, no mandatory outputs. You're a thinking partner helping the user explore.
+
+---
+
+## The Stance
+
+- **Curious, not prescriptive** - Ask questions that emerge naturally, don't follow a script
+- **Open threads, not interrogations** - Surface multiple interesting directions and let the user follow what resonates. Don't funnel them through a single path of questions.
+- **Visual** - Use ASCII diagrams liberally when they'd help clarify thinking
+- **Adaptive** - Follow interesting threads, pivot when new information emerges
+- **Patient** - Don't rush to conclusions, let the shape of the problem emerge
+- **Grounded** - Explore the actual codebase when relevant, don't just theorize
+
+---
+
+## What You Might Do
+
+Depending on what the user brings, you might:
+
+**Explore the problem space**
+- Ask clarifying questions that emerge from what they said
+- Challenge assumptions
+- Reframe the problem
+- Find analogies
+
+**Investigate the codebase**
+- Map existing architecture relevant to the discussion
+- Find integration points
+- Identify patterns already in use
+- Surface hidden complexity
+
+**Compare options**
+- Brainstorm multiple approaches
+- Build comparison tables
+- Sketch tradeoffs
+- Recommend a path (if asked)
+
+**Visualize**
+```
+┌─────────────────────────────────────────┐
+│     Use ASCII diagrams liberally        │
+├─────────────────────────────────────────┤
+│                                         │
+│      ┌────────┐         ┌────────┐      │
+│      │ State  │────────▶│ State  │      │
+│      │   A    │         │   B    │      │
+│      └────────┘         └────────┘      │
+│                                         │
+│   System diagrams, state machines,      │
+│   data flows, architecture sketches,    │
+│   dependency graphs, comparison tables  │
+│                                         │
+└─────────────────────────────────────────┘
+```
+
+**Surface risks and unknowns**
+- Identify what could go wrong
+- Find gaps in understanding
+- Suggest spikes or investigations
+
+---
+
+## OpenSpec Awareness
+
+You have full context of the OpenSpec system. Use it naturally, don't force it.
+
+### Check for context
+
+At the start, quickly check what exists:
+```bash
+openspec list --json
+```
+
+This tells you:
+- If there are active changes
+- Their names, schemas, and status
+- What the user might be working on
+
+### When no change exists
+
+Think freely. When insights crystallize, you might offer:
+
+- "This feels solid enough to start a change. Want me to create a proposal?"
+- Or keep exploring - no pressure to formalize
+
+### When a change exists
+
+If the user mentions a change or you detect one is relevant:
+
+1. **Resolve and read existing artifacts for context**
+   - Run `openspec status --change "<name>" --json`.
+   - Use `changeRoot`, `artifactPaths`, and `actionContext` from the status JSON.
+   - Read existing files from `artifactPaths.<artifact>.existingOutputPaths`.
+
+2. **Reference them naturally in conversation**
+   - "Your design mentions using Redis, but we just realized SQLite fits better..."
+   - "The proposal scopes this to premium users, but we're now thinking everyone..."
+
+3. **Offer to capture when decisions are made**
+
+    | Insight Type               | Where to Capture               |
+    |----------------------------|--------------------------------|
+    | New requirement discovered | `specs/<capability>/spec.md` |
+    | Requirement changed        | `specs/<capability>/spec.md` |
+    | Design decision made       | `design.md`                  |
+    | Scope changed              | `proposal.md`                |
+    | New work identified        | `tasks.md`                   |
+    | Assumption invalidated     | Relevant artifact              |
+
+   Example offers:
+   - "That's a design decision. Capture it in design.md?"
+   - "This is a new requirement. Add it to specs?"
+   - "This changes scope. Update the proposal?"
+
+4. **The user decides** - Offer and move on. Don't pressure. Don't auto-capture.
+
+---
+
+## What You Don't Have To Do
+
+- Follow a script
+- Ask the same questions every time
+- Produce a specific artifact
+- Reach a conclusion
+- Stay on topic if a tangent is valuable
+- Be brief (this is thinking time)
+
+---
+
+## Handling Different Entry Points
+
+**User brings a vague idea:**
+```
+User: I'm thinking about adding real-time collaboration
+
+You: Real-time collab is a big space. Let me think about this...
+
+      COLLABORATION SPECTRUM
+      ════════════════════════════════════════════
+
+      Awareness          Coordination         Sync
+          │                   │                 │
+          ▼                   ▼                 ▼
+      ┌────────┐         ┌────────┐        ┌────────┐
+      │Presence│         │Cursors │        │  CRDT  │
+      │  "3    │         │ Multi  │        │Conflict│
+      │online" │         │ select │        │  free  │
+      └────────┘         └────────┘        └────────┘
+          │                   │                 │
+       trivial            moderate           complex
+
+      Where's your head at?
+```
+
+**User brings a specific problem:**
+```
+User: The auth system is a mess
+
+You: [reads codebase]
+
+     ┌─────────────────────────────────────────────┐
+     │              CURRENT AUTH FLOW              │
+     └─────────────────────────────────────────────┘
+                        │
+          ┌─────────────┼─────────────┐
+          ▼             ▼             ▼
+     ┌─────────┐  ┌─────────┐  ┌─────────┐
+     │ Google  │  │  GitHub │  │  Email  │
+     │  OAuth  │  │  OAuth  │  │  Magic  │
+     └────┬────┘  └────┬────┘  └────┬────┘
+          │             │             │
+          └─────────────┼─────────────┘
+                        ▼
+                  ┌───────────┐
+                  │  Session  │
+                  └─────┬─────┘
+                        │
+                        ▼
+                  ┌───────────┐
+                  │   Perms   │
+                  └───────────┘
+
+     I see three tangles. Which one's burning?
+```
+
+**User is stuck mid-implementation:**
+```
+User: /opsx:explore add-auth-system
+      The OAuth integration is more complex than expected
+
+You: [reads change artifacts]
+
+     You're on task 4: "Implement OAuth flow"
+
+     Let me trace what's involved...
+
+     [draws diagram, explores options, suggests paths]
+
+     Want to update the design to reflect this?
+     Or add a spike task to investigate?
+```
+
+**User wants to compare options:**
+```
+User: Should we use Postgres or SQLite?
+
+You: Generic answer is boring. What's the context?
+
+User: A CLI tool that tracks local dev environments
+
+You: That changes everything.
+
+     ┌─────────────────────────────────────────────────┐
+     │          CLI TOOL DATA STORAGE                  │
+     └─────────────────────────────────────────────────┘
+
+     Key constraints:
+     • No daemon running
+     • Must work offline
+     • Single user
+
+                  SQLite          Postgres
+     Deployment   embedded ✓      needs server ✗
+     Offline      yes ✓           no ✗
+     Single file  yes ✓           no ✗
+
+     SQLite. Not even close.
+
+     Unless... is there a sync component?
+```
+
+---
+
+## Ending Discovery
+
+There's no required ending. Discovery might:
+
+- **Flow into a proposal**: "Ready to start? I can create a change proposal."
+- **Result in artifact updates**: "Updated design.md with these decisions"
+- **Just provide clarity**: User has what they need, moves on
+- **Continue later**: "We can pick this up anytime"
+
+When it feels like things are crystallizing, you might summarize:
+
+```
+## What We Figured Out
+
+**The problem**: [crystallized understanding]
+
+**The approach**: [if one emerged]
+
+**Open questions**: [if any remain]
+
+**Next steps** (if ready):
+- Create a change proposal
+- Keep exploring: just keep talking
+```
+
+But this summary is optional. Sometimes the thinking IS the value.
+
+---
+
+## Guardrails
+
+- **Don't implement** - Never write code or implement features. Creating OpenSpec artifacts is fine, writing application code is not.
+- **Don't fake understanding** - If something is unclear, dig deeper
+- **Don't rush** - Discovery is thinking time, not task time
+- **Don't force structure** - Let patterns emerge naturally
+- **Don't auto-capture** - Offer to save insights, don't just do it
+- **Do visualize** - A good diagram is worth many paragraphs
+- **Do explore the codebase** - Ground discussions in reality
+- **Do question assumptions** - Including the user's and your own

--- a/.github/skills/openspec-propose/SKILL.md
+++ b/.github/skills/openspec-propose/SKILL.md
@@ -1,0 +1,111 @@
+---
+name: openspec-propose
+description: Propose a new change with all artifacts generated in one step. Use when the user wants to quickly describe what they want to build and get a complete proposal with design, specs, and tasks ready for implementation.
+license: MIT
+compatibility: Requires openspec CLI.
+metadata:
+  author: openspec
+  version: "1.0"
+  generatedBy: "1.4.1"
+---
+
+Propose a new change - create the change and generate all artifacts in one step.
+
+I'll create a change with artifacts:
+- proposal.md (what & why)
+- design.md (how)
+- tasks.md (implementation steps)
+
+When ready to implement, run /opsx:apply
+
+---
+
+**Input**: The user's request should include a change name (kebab-case) OR a description of what they want to build.
+
+**Steps**
+
+1. **If no clear input provided, ask what they want to build**
+
+   Use the **AskUserQuestion tool** (open-ended, no preset options) to ask:
+   > "What change do you want to work on? Describe what you want to build or fix."
+
+   From their description, derive a kebab-case name (e.g., "add user authentication" → `add-user-auth`).
+
+   **IMPORTANT**: Do NOT proceed without understanding what the user wants to build.
+
+2. **Create the change directory**
+   ```bash
+   openspec new change "<name>"
+   ```
+   This creates a scaffolded change in the planning home resolved by the CLI with `.openspec.yaml`.
+
+3. **Get the artifact build order**
+   ```bash
+   openspec status --change "<name>" --json
+   ```
+   Parse the JSON to get:
+   - `applyRequires`: array of artifact IDs needed before implementation (e.g., `["tasks"]`)
+   - `artifacts`: list of all artifacts with their status and dependencies
+   - `planningHome`, `changeRoot`, `artifactPaths`, and `actionContext`: path and scope context. Use these instead of assuming repo-local paths.
+
+4. **Create artifacts in sequence until apply-ready**
+
+   Use the **TodoWrite tool** to track progress through the artifacts.
+
+   Loop through artifacts in dependency order (artifacts with no pending dependencies first):
+
+   a. **For each artifact that is `ready` (dependencies satisfied)**:
+      - Get instructions:
+        ```bash
+        openspec instructions <artifact-id> --change "<name>" --json
+        ```
+      - The instructions JSON includes:
+        - `context`: Project background (constraints for you - do NOT include in output)
+        - `rules`: Artifact-specific rules (constraints for you - do NOT include in output)
+        - `template`: The structure to use for your output file
+        - `instruction`: Schema-specific guidance for this artifact type
+        - `resolvedOutputPath`: Resolved path or pattern to write the artifact
+        - `dependencies`: Completed artifacts to read for context
+      - Read any completed dependency files for context
+      - Create the artifact file using `template` as the structure and write it to `resolvedOutputPath`
+      - Apply `context` and `rules` as constraints - but do NOT copy them into the file
+      - Show brief progress: "Created <artifact-id>"
+
+   b. **Continue until all `applyRequires` artifacts are complete**
+      - After creating each artifact, re-run `openspec status --change "<name>" --json`
+      - Check if every artifact ID in `applyRequires` has `status: "done"` in the artifacts array
+      - Stop when all `applyRequires` artifacts are done
+
+   c. **If an artifact requires user input** (unclear context):
+      - Use **AskUserQuestion tool** to clarify
+      - Then continue with creation
+
+5. **Show final status**
+   ```bash
+   openspec status --change "<name>"
+   ```
+
+**Output**
+
+After completing all artifacts, summarize:
+- Change name and location
+- List of artifacts created with brief descriptions
+- What's ready: "All artifacts created! Ready for implementation."
+- Prompt: "Run `/opsx:apply` or ask me to implement to start working on the tasks."
+
+**Artifact Creation Guidelines**
+
+- Follow the `instruction` field from `openspec instructions` for each artifact type
+- The schema defines what each artifact should contain - follow it
+- Read dependency artifacts for context before creating new ones
+- Use `template` as the structure for your output file - fill in its sections
+- **IMPORTANT**: `context` and `rules` are constraints for YOU, not content for the file
+  - Do NOT copy `<context>`, `<rules>`, `<project_context>` blocks into the artifact
+  - These guide what you write, but should never appear in the output
+
+**Guardrails**
+- Create ALL artifacts needed for implementation (as defined by schema's `apply.requires`)
+- Always read dependency artifacts before creating a new one
+- If context is critically unclear, ask the user - but prefer making reasonable decisions to keep momentum
+- If a change with that name already exists, ask if user wants to continue it or create a new one
+- Verify each artifact file exists after writing before proceeding to next

--- a/.gitignore
+++ b/.gitignore
@@ -66,7 +66,3 @@ test_source.json
 app
 log.txt
 
-# openspec: track config, specs, and active changes (for PR review).
-# Archived changes are redundant — their rationale is merged into openspec/specs/
-# on `openspec archive`, which is the single source of truth.
-openspec/changes/archive/

--- a/.gitignore
+++ b/.gitignore
@@ -65,3 +65,8 @@ test_source.json
 # go binary name
 app
 log.txt
+
+# openspec: track config, specs, and active changes (for PR review).
+# Archived changes are redundant — their rationale is merged into openspec/specs/
+# on `openspec archive`, which is the single source of truth.
+openspec/changes/archive/

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -13,3 +13,23 @@ Install the required pre-commit hooks.
 ```shell
 pre-commit install -t commit-msg
 ```
+
+## OpenSpec Workflow
+
+Use this flow for spec-driven changes. The **spec is the single source of truth**: its `## Purpose` section carries the design rationale (intent, goals, non-goals, key decisions) ADR-style, so we don't keep separate ADR/design files.
+
+1. Propose: `openspec new change <name>` and complete `proposal.md`, `design.md`, `tasks.md`, and delta specs.
+2. Implement: complete tasks in `openspec/changes/<name>/tasks.md`.
+3. Validate: run `openspec validate --all`. This is the structural/drift check — it fails on malformed specs or deltas.
+4. Archive: run `openspec archive <name>`. This updates the main specs (applies deltas into `openspec/specs/`) and moves the change under `openspec/changes/archive/`. There is no separate `sync` command; `archive` is the sync.
+
+Commit active changes under `openspec/changes/` so they're reviewed in their PR. The archive (`openspec/changes/archive/`) is gitignored — its rationale already lives in the spec `## Purpose`.
+
+## Spec Writing Policy (Human + Agent)
+
+Keep specs layered so they are readable by humans and usable by agents:
+
+1. `## Purpose` is the **why**: concise context, goals/non-goals, key decisions, and major trade-offs.
+2. `## Requirements` is the **what**: normative, testable behavior using `MUST`/`SHALL`/`SHOULD`/`MAY` with scenario blocks.
+3. Do not copy proposal/design/tasks verbatim into specs.
+4. Keep implementation planning detail in change artifacts (`design.md`, `tasks.md`), not in canonical specs.

--- a/cmd/groups_cmd.go
+++ b/cmd/groups_cmd.go
@@ -1,0 +1,155 @@
+// Copyright 2026 Canonical Ltd.
+// SPDX-License-Identifier: AGPL-3.0-only
+
+package cmd
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+
+	"github.com/spf13/cobra"
+)
+
+// groupsCmd is the parent command for group membership management operations.
+var groupsCmd = &cobra.Command{
+	Use:   "groups",
+	Short: "Manage group memberships",
+	Long:  `Manage group memberships directly in the database.`,
+}
+
+// groupsAddUsersCmd adds users to a group.
+var groupsAddUsersCmd = &cobra.Command{
+	Use:   "add-users <group-id>",
+	Short: "Add users to a group",
+	Args:  cobra.ExactArgs(1),
+	Run: func(cmd *cobra.Command, args []string) {
+		if err := runGroupsAddUsers(cmd, args[0]); err != nil {
+			fmt.Fprintf(os.Stderr, "Error: %v\n", err)
+			os.Exit(1)
+		}
+	},
+}
+
+// groupsRemoveUsersCmd removes users from a group.
+var groupsRemoveUsersCmd = &cobra.Command{
+	Use:   "remove-users <group-id>",
+	Short: "Remove users from a group",
+	Args:  cobra.ExactArgs(1),
+	Run: func(cmd *cobra.Command, args []string) {
+		if err := runGroupsRemoveUsers(cmd, args[0]); err != nil {
+			fmt.Fprintf(os.Stderr, "Error: %v\n", err)
+			os.Exit(1)
+		}
+	},
+}
+
+// groupsListUsersCmd lists all users in a group.
+var groupsListUsersCmd = &cobra.Command{
+	Use:   "list-users <group-id>",
+	Short: "List all users in a group",
+	Args:  cobra.ExactArgs(1),
+	Run: func(cmd *cobra.Command, args []string) {
+		if err := runGroupsListUsers(cmd, args[0]); err != nil {
+			fmt.Fprintf(os.Stderr, "Error: %v\n", err)
+			os.Exit(1)
+		}
+	},
+}
+
+func init() {
+	for _, sub := range []*cobra.Command{groupsAddUsersCmd, groupsRemoveUsersCmd, groupsListUsersCmd} {
+		sub.Flags().String("dsn", "", "PostgreSQL DSN connection string")
+		sub.Flags().StringP("format", "f", "text", "Output format (text or json)")
+		_ = sub.MarkFlagRequired("dsn")
+	}
+
+	groupsAddUsersCmd.Flags().StringSliceP("user", "u", nil, "User ID to add (repeatable, or comma-separated)")
+	_ = groupsAddUsersCmd.MarkFlagRequired("user")
+	groupsRemoveUsersCmd.Flags().StringSliceP("user", "u", nil, "User ID to remove (repeatable, or comma-separated)")
+
+	groupsCmd.AddCommand(groupsAddUsersCmd)
+	groupsCmd.AddCommand(groupsRemoveUsersCmd)
+	groupsCmd.AddCommand(groupsListUsersCmd)
+
+	rootCmd.AddCommand(groupsCmd)
+}
+
+// runGroupsAddUsers adds users to a group.
+func runGroupsAddUsers(cmd *cobra.Command, groupID string) error {
+	s, cleanup, err := newStorageFromCmd(cmd)
+	if err != nil {
+		return err
+	}
+	defer cleanup()
+
+	userIDs, _ := cmd.Flags().GetStringSlice("user")
+
+	if err := s.AddUsersToGroup(cmd.Context(), groupID, userIDs); err != nil {
+		return fmt.Errorf("failed to add users to group %q: %v", groupID, err)
+	}
+
+	format, _ := cmd.Flags().GetString("format")
+	if format == "json" {
+		return json.NewEncoder(cmd.OutOrStdout()).Encode(map[string]interface{}{
+			"group_id":    groupID,
+			"users_added": len(userIDs),
+		})
+	}
+
+	fmt.Fprintf(cmd.OutOrStdout(), "Added %d users to group %s\n", len(userIDs), groupID)
+	return nil
+}
+
+// runGroupsRemoveUsers removes users from a group.
+func runGroupsRemoveUsers(cmd *cobra.Command, groupID string) error {
+	s, cleanup, err := newStorageFromCmd(cmd)
+	if err != nil {
+		return err
+	}
+	defer cleanup()
+
+	userIDs, _ := cmd.Flags().GetStringSlice("user")
+
+	if err := s.RemoveUsersFromGroup(cmd.Context(), groupID, userIDs); err != nil {
+		return fmt.Errorf("failed to remove users from group %q: %v", groupID, err)
+	}
+
+	format, _ := cmd.Flags().GetString("format")
+	if format == "json" {
+		return json.NewEncoder(cmd.OutOrStdout()).Encode(map[string]interface{}{
+			"group_id":      groupID,
+			"users_removed": len(userIDs),
+		})
+	}
+
+	fmt.Fprintf(cmd.OutOrStdout(), "Removed %d users from group %s\n", len(userIDs), groupID)
+	return nil
+}
+
+// runGroupsListUsers lists all users in a group.
+func runGroupsListUsers(cmd *cobra.Command, groupID string) error {
+	s, cleanup, err := newStorageFromCmd(cmd)
+	if err != nil {
+		return err
+	}
+	defer cleanup()
+
+	userIDs, err := s.ListUsersInGroup(cmd.Context(), groupID)
+	if err != nil {
+		return fmt.Errorf("failed to list users in group %q: %v", groupID, err)
+	}
+
+	format, _ := cmd.Flags().GetString("format")
+	if format == "json" {
+		if userIDs == nil {
+			userIDs = []string{}
+		}
+		return json.NewEncoder(cmd.OutOrStdout()).Encode(userIDs)
+	}
+
+	for _, uid := range userIDs {
+		fmt.Fprintln(cmd.OutOrStdout(), uid)
+	}
+	return nil
+}

--- a/cmd/groups_cmd_test.go
+++ b/cmd/groups_cmd_test.go
@@ -1,0 +1,199 @@
+// Copyright 2026 Canonical Ltd.
+// SPDX-License-Identifier: AGPL-3.0-only
+
+package cmd
+
+import (
+	"testing"
+
+	"github.com/spf13/cobra"
+)
+
+func TestGroupsAddUsersRequiresDSN(t *testing.T) {
+	cmd := &cobra.Command{}
+	cmd.Flags().String("dsn", "", "")
+	cmd.Flags().StringP("format", "f", "text", "")
+	cmd.Flags().StringSliceP("user", "u", nil, "")
+
+	err := runGroupsAddUsers(cmd, "group-id-1")
+	if err == nil {
+		t.Fatal("expected error when dsn is empty")
+	}
+}
+
+func TestGroupsRemoveUsersRequiresDSN(t *testing.T) {
+	cmd := &cobra.Command{}
+	cmd.Flags().String("dsn", "", "")
+	cmd.Flags().StringP("format", "f", "text", "")
+	cmd.Flags().StringSliceP("user", "u", nil, "")
+
+	err := runGroupsRemoveUsers(cmd, "group-id-1")
+	if err == nil {
+		t.Fatal("expected error when dsn is empty")
+	}
+}
+
+func TestGroupsListUsersRequiresDSN(t *testing.T) {
+	cmd := &cobra.Command{}
+	cmd.Flags().String("dsn", "", "")
+	cmd.Flags().StringP("format", "f", "text", "")
+
+	err := runGroupsListUsers(cmd, "group-id-1")
+	if err == nil {
+		t.Fatal("expected error when dsn is empty")
+	}
+}
+
+func TestGroupsAddUsersSubcommandExactArgs(t *testing.T) {
+	tests := []struct {
+		name    string
+		args    []string
+		wantErr bool
+	}{
+		{
+			name:    "no args",
+			args:    []string{},
+			wantErr: true,
+		},
+		{
+			name:    "one arg",
+			args:    []string{"group-id-1"},
+			wantErr: false,
+		},
+		{
+			name:    "two args",
+			args:    []string{"group-id-1", "extra"},
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := cobra.ExactArgs(1)(groupsAddUsersCmd, tt.args)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("ExactArgs(1) error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}
+
+func TestGroupsRemoveUsersSubcommandExactArgs(t *testing.T) {
+	tests := []struct {
+		name    string
+		args    []string
+		wantErr bool
+	}{
+		{
+			name:    "no args",
+			args:    []string{},
+			wantErr: true,
+		},
+		{
+			name:    "one arg",
+			args:    []string{"group-id-1"},
+			wantErr: false,
+		},
+		{
+			name:    "two args",
+			args:    []string{"group-id-1", "extra"},
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := cobra.ExactArgs(1)(groupsRemoveUsersCmd, tt.args)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("ExactArgs(1) error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}
+
+func TestGroupsListUsersSubcommandExactArgs(t *testing.T) {
+	tests := []struct {
+		name    string
+		args    []string
+		wantErr bool
+	}{
+		{
+			name:    "no args",
+			args:    []string{},
+			wantErr: true,
+		},
+		{
+			name:    "one arg",
+			args:    []string{"group-id-1"},
+			wantErr: false,
+		},
+		{
+			name:    "two args",
+			args:    []string{"group-id-1", "extra"},
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := cobra.ExactArgs(1)(groupsListUsersCmd, tt.args)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("ExactArgs(1) error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}
+
+func TestImportCmdSyncFlag(t *testing.T) {
+	tests := []struct {
+		name    string
+		driver  string
+		wantErr bool
+	}{
+		{
+			name:    "unsupported driver with sync",
+			driver:  "unknown",
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cmd := &cobra.Command{}
+			cmd.Flags().String("driver", "", "")
+			cmd.Flags().String("dsn", "", "")
+			cmd.Flags().String("domain", "", "")
+			cmd.Flags().String("consumer-key", "", "")
+			cmd.Flags().String("consumer-secret", "", "")
+			cmd.Flags().Bool("sync", false, "")
+
+			cmd.Flags().Set("driver", tt.driver)
+			cmd.Flags().Set("dsn", "postgres://user:pass@localhost:5432/db")
+			cmd.Flags().Set("sync", "true")
+
+			err := runImport(cmd)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("runImport() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}
+
+// TestGroupsAddUsersRequiresUserFlag verifies that the --user flag is marked
+// required on the add-users subcommand, preventing silent no-ops when it is omitted.
+func TestGroupsAddUsersRequiresUserFlag(t *testing.T) {
+	parent := &cobra.Command{Use: "hook-service"}
+	child := &cobra.Command{
+		Use:  "add-users <group-id>",
+		Args: cobra.ExactArgs(1),
+		Run:  func(cmd *cobra.Command, args []string) {},
+	}
+	child.Flags().String("dsn", "", "")
+	child.Flags().StringSliceP("user", "u", nil, "")
+	_ = child.MarkFlagRequired("user")
+	parent.AddCommand(child)
+
+	parent.SetArgs([]string{"add-users", "group-id-1", "--dsn", "postgres://x"})
+	if err := parent.Execute(); err == nil {
+		t.Fatal("expected error when --user flag is omitted")
+	}
+}

--- a/cmd/import.go
+++ b/cmd/import.go
@@ -4,16 +4,17 @@
 package cmd
 
 import (
-	"context"
 	"fmt"
 	"os"
 
 	"github.com/spf13/cobra"
 
+	"github.com/canonical/hook-service/internal/authorization"
 	"github.com/canonical/hook-service/internal/db"
 	"github.com/canonical/hook-service/internal/importer"
 	"github.com/canonical/hook-service/internal/logging"
 	"github.com/canonical/hook-service/internal/monitoring/prometheus"
+	"github.com/canonical/hook-service/internal/openfga"
 	"github.com/canonical/hook-service/internal/salesforce"
 	"github.com/canonical/hook-service/internal/storage"
 	"github.com/canonical/hook-service/internal/tracing"
@@ -43,6 +44,11 @@ func init() {
 	importCmd.Flags().String("domain", "", "Salesforce domain")
 	importCmd.Flags().String("consumer-key", "", "Salesforce consumer key")
 	importCmd.Flags().String("consumer-secret", "", "Salesforce consumer secret")
+	importCmd.Flags().Bool("sync", false, "Reconcile DB with driver data, removing stale groups and memberships")
+	importCmd.Flags().String("openfga-host", "", "OpenFGA API host (optional, for authorization tuple cleanup on --sync)")
+	importCmd.Flags().String("openfga-store-id", "", "OpenFGA store ID")
+	importCmd.Flags().String("openfga-token", "", "OpenFGA API token")
+	importCmd.Flags().String("openfga-model-id", "", "OpenFGA authorization model ID")
 
 	_ = importCmd.MarkFlagRequired("driver")
 	_ = importCmd.MarkFlagRequired("dsn")
@@ -88,8 +94,30 @@ func runImport(cmd *cobra.Command) error {
 		return fmt.Errorf("unsupported driver: %q (supported: salesforce)", driver)
 	}
 
-	imp := importer.NewImporter(importDriver, s, logger)
-	return imp.Run(context.Background())
+	imp := importer.NewImporter(importDriver, s, buildAuthorizer(cmd, tracer, monitor, logger), logger)
+
+	sync, _ := cmd.Flags().GetBool("sync")
+	if sync {
+		return imp.Sync(cmd.Context())
+	}
+	return imp.Run(cmd.Context())
+}
+
+// buildAuthorizer constructs an Authorizer from the --openfga-* flags.
+// If no OpenFGA host is provided it falls back to the noop authorizer, which
+// is correct when authorization is disabled or the import is run without --sync.
+func buildAuthorizer(cmd *cobra.Command, tracer *tracing.Tracer, monitor *prometheus.Monitor, logger logging.LoggerInterface) *authorization.Authorizer {
+	host, _ := cmd.Flags().GetString("openfga-host")
+	if host == "" {
+		return authorization.NewAuthorizer(openfga.NewNoopClient(tracer, monitor, logger), tracer, monitor, logger)
+	}
+
+	storeID, _ := cmd.Flags().GetString("openfga-store-id")
+	token, _ := cmd.Flags().GetString("openfga-token")
+	modelID, _ := cmd.Flags().GetString("openfga-model-id")
+
+	ofga := openfga.NewClient(openfga.NewConfig("", host, storeID, token, modelID, false, tracer, monitor, logger))
+	return authorization.NewAuthorizer(ofga, tracer, monitor, logger)
 }
 
 func buildSalesforceDriver(cmd *cobra.Command) (*importer.SalesforceDriver, error) {

--- a/cmd/users.go
+++ b/cmd/users.go
@@ -1,0 +1,190 @@
+// Copyright 2026 Canonical Ltd.
+// SPDX-License-Identifier: AGPL-3.0-only
+
+package cmd
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+
+	"github.com/spf13/cobra"
+
+	"github.com/canonical/hook-service/internal/db"
+	"github.com/canonical/hook-service/internal/logging"
+	"github.com/canonical/hook-service/internal/monitoring/prometheus"
+	"github.com/canonical/hook-service/internal/storage"
+	"github.com/canonical/hook-service/internal/tracing"
+	"github.com/canonical/hook-service/internal/types"
+)
+
+// usersCmd is the parent command for user management operations.
+var usersCmd = &cobra.Command{
+	Use:   "users",
+	Short: "Manage user group memberships",
+	Long:  `Manage user group memberships directly in the database.`,
+}
+
+// usersDeleteCmd removes a user from all groups.
+var usersDeleteCmd = &cobra.Command{
+	Use:   "delete <user-id>",
+	Short: "Remove a user from all groups",
+	Args:  cobra.ExactArgs(1),
+	Run: func(cmd *cobra.Command, args []string) {
+		if err := runUsersDelete(cmd, args[0]); err != nil {
+			fmt.Fprintf(os.Stderr, "Error: %v\n", err)
+			os.Exit(1)
+		}
+	},
+}
+
+// usersListGroupsCmd lists all groups a user belongs to.
+var usersListGroupsCmd = &cobra.Command{
+	Use:   "list-groups <user-id>",
+	Short: "List all groups a user belongs to",
+	Args:  cobra.ExactArgs(1),
+	Run: func(cmd *cobra.Command, args []string) {
+		if err := runUsersListGroups(cmd, args[0]); err != nil {
+			fmt.Fprintf(os.Stderr, "Error: %v\n", err)
+			os.Exit(1)
+		}
+	},
+}
+
+// usersSetGroupsCmd replaces a user's group memberships.
+var usersSetGroupsCmd = &cobra.Command{
+	Use:   "set-groups <user-id>",
+	Short: "Replace a user's group memberships with the specified groups",
+	Args:  cobra.ExactArgs(1),
+	Run: func(cmd *cobra.Command, args []string) {
+		if err := runUsersSetGroups(cmd, args[0]); err != nil {
+			fmt.Fprintf(os.Stderr, "Error: %v\n", err)
+			os.Exit(1)
+		}
+	},
+}
+
+func init() {
+	for _, sub := range []*cobra.Command{usersDeleteCmd, usersListGroupsCmd, usersSetGroupsCmd} {
+		sub.Flags().String("dsn", "", "PostgreSQL DSN connection string")
+		sub.Flags().StringP("format", "f", "text", "Output format (text or json)")
+		_ = sub.MarkFlagRequired("dsn")
+	}
+
+	usersSetGroupsCmd.Flags().StringSliceP("group", "g", nil, "Group ID to assign (repeatable, or comma-separated)")
+	_ = usersSetGroupsCmd.MarkFlagRequired("group")
+
+	usersCmd.AddCommand(usersDeleteCmd)
+	usersCmd.AddCommand(usersListGroupsCmd)
+	usersCmd.AddCommand(usersSetGroupsCmd)
+
+	rootCmd.AddCommand(usersCmd)
+}
+
+// newStorageFromCmd creates a storage client from the --dsn flag on cmd.
+func newStorageFromCmd(cmd *cobra.Command) (*storage.Storage, func(), error) {
+	dsn, _ := cmd.Flags().GetString("dsn")
+	if dsn == "" {
+		return nil, nil, fmt.Errorf("--dsn is required")
+	}
+
+	logger := logging.NewLogger("error")
+	monitor := prometheus.NewMonitor("hook-service", logger)
+	tracer := tracing.NewTracer(tracing.NewConfig(false, "", "", logger))
+
+	dbConfig := db.Config{
+		DSN:      dsn,
+		MaxConns: 10,
+		MinConns: 1,
+	}
+
+	dbClient, err := db.NewDBClient(dbConfig, tracer, monitor, logger)
+	if err != nil {
+		return nil, nil, fmt.Errorf("failed to connect to database: %v", err)
+	}
+
+	s := storage.NewStorage(dbClient, tracer, monitor, logger)
+	cleanup := func() {
+		dbClient.Close()
+		logger.Sync()
+	}
+
+	return s, cleanup, nil
+}
+
+// runUsersDelete removes a user from all groups.
+func runUsersDelete(cmd *cobra.Command, userID string) error {
+	s, cleanup, err := newStorageFromCmd(cmd)
+	if err != nil {
+		return err
+	}
+	defer cleanup()
+
+	if err := s.RemoveUserFromAllGroups(cmd.Context(), userID); err != nil {
+		return fmt.Errorf("failed to delete user %q: %v", userID, err)
+	}
+
+	format, _ := cmd.Flags().GetString("format")
+	if format == "json" {
+		return json.NewEncoder(cmd.OutOrStdout()).Encode(map[string]string{
+			"user_id": userID,
+			"status":  "deleted",
+		})
+	}
+
+	fmt.Fprintf(cmd.OutOrStdout(), "Deleted user %s from all groups\n", userID)
+	return nil
+}
+
+// runUsersListGroups lists all groups a user belongs to.
+func runUsersListGroups(cmd *cobra.Command, userID string) error {
+	s, cleanup, err := newStorageFromCmd(cmd)
+	if err != nil {
+		return err
+	}
+	defer cleanup()
+
+	groups, err := s.GetGroupsForUser(cmd.Context(), userID)
+	if err != nil {
+		return fmt.Errorf("failed to list groups for user %q: %v", userID, err)
+	}
+
+	format, _ := cmd.Flags().GetString("format")
+	if format == "json" {
+		if groups == nil {
+			groups = []*types.Group{}
+		}
+		return json.NewEncoder(cmd.OutOrStdout()).Encode(groups)
+	}
+
+	for _, g := range groups {
+		fmt.Fprintln(cmd.OutOrStdout(), g.Name)
+	}
+	return nil
+}
+
+// runUsersSetGroups replaces a user's group memberships.
+func runUsersSetGroups(cmd *cobra.Command, userID string) error {
+	s, cleanup, err := newStorageFromCmd(cmd)
+	if err != nil {
+		return err
+	}
+	defer cleanup()
+
+	groupIDs, _ := cmd.Flags().GetStringSlice("group")
+
+	if err := s.UpdateGroupsForUser(cmd.Context(), userID, groupIDs); err != nil {
+		return fmt.Errorf("failed to set groups for user %q: %v", userID, err)
+	}
+
+	format, _ := cmd.Flags().GetString("format")
+	if format == "json" {
+		return json.NewEncoder(cmd.OutOrStdout()).Encode(map[string]interface{}{
+			"user_id": userID,
+			"groups":  groupIDs,
+		})
+	}
+
+	fmt.Fprintf(cmd.OutOrStdout(), "Updated groups for user %s\n", userID)
+	return nil
+}

--- a/cmd/users_test.go
+++ b/cmd/users_test.go
@@ -1,0 +1,164 @@
+// Copyright 2026 Canonical Ltd.
+// SPDX-License-Identifier: AGPL-3.0-only
+
+package cmd
+
+import (
+	"testing"
+
+	"github.com/spf13/cobra"
+)
+
+func TestUsersDeleteRequiresDSN(t *testing.T) {
+	cmd := &cobra.Command{}
+	cmd.Flags().String("dsn", "", "")
+	cmd.Flags().StringP("format", "f", "text", "")
+
+	err := runUsersDelete(cmd, "alice@example.com")
+	if err == nil {
+		t.Fatal("expected error when dsn is empty")
+	}
+}
+
+func TestUsersListGroupsRequiresDSN(t *testing.T) {
+	cmd := &cobra.Command{}
+	cmd.Flags().String("dsn", "", "")
+	cmd.Flags().StringP("format", "f", "text", "")
+
+	err := runUsersListGroups(cmd, "alice@example.com")
+	if err == nil {
+		t.Fatal("expected error when dsn is empty")
+	}
+}
+
+func TestUsersSetGroupsRequiresDSN(t *testing.T) {
+	cmd := &cobra.Command{}
+	cmd.Flags().String("dsn", "", "")
+	cmd.Flags().StringP("format", "f", "text", "")
+	cmd.Flags().StringSliceP("group", "g", nil, "")
+
+	err := runUsersSetGroups(cmd, "alice@example.com")
+	if err == nil {
+		t.Fatal("expected error when dsn is empty")
+	}
+}
+
+func TestUsersDeleteSubcommandExactArgs(t *testing.T) {
+	tests := []struct {
+		name    string
+		args    []string
+		wantErr bool
+	}{
+		{
+			name:    "no args",
+			args:    []string{},
+			wantErr: true,
+		},
+		{
+			name:    "one arg",
+			args:    []string{"alice@example.com"},
+			wantErr: false,
+		},
+		{
+			name:    "two args",
+			args:    []string{"alice@example.com", "extra"},
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := cobra.ExactArgs(1)(usersDeleteCmd, tt.args)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("ExactArgs(1) error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}
+
+func TestUsersListGroupsSubcommandExactArgs(t *testing.T) {
+	tests := []struct {
+		name    string
+		args    []string
+		wantErr bool
+	}{
+		{
+			name:    "no args",
+			args:    []string{},
+			wantErr: true,
+		},
+		{
+			name:    "one arg",
+			args:    []string{"alice@example.com"},
+			wantErr: false,
+		},
+		{
+			name:    "two args",
+			args:    []string{"alice@example.com", "extra"},
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := cobra.ExactArgs(1)(usersListGroupsCmd, tt.args)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("ExactArgs(1) error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}
+
+func TestUsersSetGroupsSubcommandExactArgs(t *testing.T) {
+	tests := []struct {
+		name    string
+		args    []string
+		wantErr bool
+	}{
+		{
+			name:    "no args",
+			args:    []string{},
+			wantErr: true,
+		},
+		{
+			name:    "one arg",
+			args:    []string{"alice@example.com"},
+			wantErr: false,
+		},
+		{
+			name:    "two args",
+			args:    []string{"alice@example.com", "extra"},
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := cobra.ExactArgs(1)(usersSetGroupsCmd, tt.args)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("ExactArgs(1) error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}
+
+// TestUsersSetGroupsRequiresGroupFlag verifies that the --group flag is marked
+// required on the set-groups subcommand, preventing accidental removal of all
+// user memberships when the flag is omitted.
+func TestUsersSetGroupsRequiresGroupFlag(t *testing.T) {
+	parent := &cobra.Command{Use: "hook-service"}
+	child := &cobra.Command{
+		Use:  "set-groups <user-id>",
+		Args: cobra.ExactArgs(1),
+		Run:  func(cmd *cobra.Command, args []string) {},
+	}
+	child.Flags().String("dsn", "", "")
+	child.Flags().StringSliceP("group", "g", nil, "")
+	_ = child.MarkFlagRequired("group")
+	parent.AddCommand(child)
+
+	parent.SetArgs([]string{"set-groups", "alice@example.com", "--dsn", "postgres://x"})
+	if err := parent.Execute(); err == nil {
+		t.Fatal("expected error when --group flag is omitted")
+	}
+}

--- a/docs/adr/003-cli-user-group-sync.md
+++ b/docs/adr/003-cli-user-group-sync.md
@@ -1,0 +1,155 @@
+# ADR-003: CLI User/Group Operations and Import Sync Mode
+
+**Status**: Accepted  
+**Date**: 2026-05-04  
+**Deciders**: Development Team  
+**Issue**: [#194](https://github.com/canonical/hook-service/issues/194)
+
+## Context
+
+After decoupling Salesforce from the token hook hot path (ADR-001), all group data lives in the local database. The `import` command can populate groups from Salesforce but only ever adds — it never removes. This means:
+
+- Users who leave the organisation remain in groups indefinitely.
+- Department transfers cannot be reconciled without manual SQL.
+- The database drifts from the source of truth over time.
+- There is no way to perform any user/group membership operations without the server running.
+
+## Decision
+
+1. Add **CLI subcommands** for manual user and group membership management:
+   - `hook-service users delete <user-id>` — remove a user from all groups
+   - `hook-service users list-groups <user-id>` — list all groups a user belongs to
+   - `hook-service users set-groups <user-id> --group ...` — replace a user's group memberships
+   - `hook-service groups add-users <group-id> --user ...` — add users to a group
+   - `hook-service groups remove-users <group-id> --user ...` — remove users from a group
+   - `hook-service groups list-users <group-id>` — list all users in a group
+
+2. Add a **sync mode** to the existing `import` command via `--sync`:  
+   `hook-service import --driver salesforce --sync --dsn ...`  
+   Sync reconciles the database with the driver, removing stale memberships and groups.
+
+## Rationale
+
+### User identification by email
+
+Users are identified by **email** throughout the system. There is no `users` table — users exist implicitly via `group_members.user_id` rows. The Salesforce driver stores `fHCM2__Email__c` as `UserID`, and the token hook looks up groups by `user.Email` from the Hydra session. CLI commands therefore accept email addresses as user IDs.
+
+### Sync scope
+
+**Only groups prefixed with the driver's prefix are affected by `--sync`.** Local/admin-created groups are never touched. This is the critical safety invariant.
+
+The prefix (`salesforce:`) is provided by the `DriverInterface.Prefix()` method. The `ListGroupsByPrefix` storage operation uses a lexicographic range query (`name >= prefix AND name < successor`) to guarantee B-tree index usage regardless of database collation. The successor is computed by incrementing the last byte of the prefix (e.g., `":"` (0x3A) → `";"` (0x3B)).
+
+### Sync algorithm
+
+```
+Sync(ctx):
+  1. FetchAllUserGroups(ctx) from driver → mappings
+  2. Build driverGroups map[prefixedName][]userID
+  3. ListGroupsByPrefix(ctx, prefix+":", tenantID) → existingGroups
+  4. Build existingByName map[name]*Group for O(1) lookup
+
+  5. For each (name, userIDs) in driverGroups:
+     if exists in existingByName → SyncGroupMembers (reconcile membership)
+     else → CreateGroup then AddUsersToGroup (new group)
+     On error: log and continue (non-fatal)
+
+  6. For each group in existingGroups NOT in driverGroups:
+     DeleteGroup (stale group — remove)
+     On error: log and continue (non-fatal)
+
+  7. Log summary: synced, created, deleted counts
+```
+
+### Email change handling
+
+When a user's email changes in Salesforce, sync handles it naturally:
+
+- Old email: removed from all `salesforce:*` groups (no longer in driver data)
+- New email: added to appropriate `salesforce:*` groups
+
+Local group memberships with the old email become stale but harmless. Admins can clean up with `users delete <old-email>`.
+
+### OpenFGA consistency
+
+All stored OpenFGA tuples are group-level (`group:<id>#member → can_access → client:<id>`). User-group membership is passed as contextual tuples at check time only. This means:
+
+- **Removing a user from groups requires zero OpenFGA cleanup** — no per-user tuples exist.
+- **Deleting a group** normally requires OpenFGA cleanup. However, the importer is a CLI tool without an OpenFGA client — it calls `storage.DeleteGroup` (DB-level only), not `pkg/groups.Service.DeleteGroup` (which also cleans up OpenFGA tuples).
+
+The orphaned OpenFGA tuples for deleted groups are harmless dead data: `FetchUserGroups` (DB query) always runs before `AuthorizeRequest`, so no contextual tuples will ever be built for a deleted group's ID.
+
+### Index strategy
+
+The `ListGroupsByPrefix` query uses `LIKE 'prefix%'` for prefix matching. This is semantically correct across all PostgreSQL collations, including `en_US.UTF-8` where a byte-level lexicographic range approach (`name >= prefix AND name < successor`) does not work correctly because letters sort differently relative to punctuation characters (e.g., `:` vs `;`) under locale-aware collation. The query relies on the existing `idx_groups_name(tenant_id, name)` composite index for the `tenant_id` equality predicate; the LIKE scan operates on the narrowed result set. At current scale (hundreds of groups per tenant), this is efficient. A dedicated `text_pattern_ops` index can be added in future if prefix scans become a bottleneck.
+
+### Idempotence
+
+All operations are designed to be idempotent:
+- `users delete` succeeds even if the user has no memberships
+- `groups remove-users` succeeds even if users are not members
+- `import --sync` is safe to run multiple times
+
+## Alternatives Considered
+
+### Modify `Run()` to also remove stale data
+- ❌ Breaking change for existing users who rely on additive-only behaviour
+- ❌ Destroying data in a background operation is not safe without explicit opt-in
+- ✅ Keeping `Run()` unchanged and adding `Sync()` preserves backward compatibility
+
+### gRPC API for user/group management
+- ✅ Server-side validation and authorization
+- ❌ Requires the server to be running
+- ❌ Over-engineered for offline administrative operations
+- ✅ CLI commands work directly against the database, suitable for operator tooling
+
+### Per-user OpenFGA cleanup in importer sync
+- ❌ Requires wiring an OpenFGA client into the CLI tool
+- ❌ Complex dependency for a batch operation
+- ✅ Orphaned tuples are harmless; full cleanup available via gRPC API's `DeleteGroup` endpoint
+
+## Consequences
+
+### Positive
+- Operators can manage group memberships without running the server
+- Import `--sync` allows automated reconciliation with external sources
+- Data staleness from the original `import` command is now fully addressable
+- All operations are idempotent and safe to retry
+
+### Negative
+- **Known limitation**: `import --sync` does not clean up OpenFGA tuples for deleted groups. A future enhancement could add an OpenFGA cleanup pass (or admins can use the gRPC API's `DeleteGroup` endpoint, which does full cleanup).
+- **`users delete` removes from ALL groups** — not just driver-prefixed ones. This is intentional (explicit admin action) but must be documented for operators.
+
+### Neutral
+- Local groups are never affected by `import --sync`.
+- `users delete` + `import --sync` are complementary: sync handles bulk reconciliation, `users delete` handles individual user offboarding.
+
+## Implementation Notes
+
+### New storage operations
+
+```go
+RemoveUserFromAllGroups(ctx context.Context, userID string) error
+ListGroupsByPrefix(ctx context.Context, prefix, tenantID string) ([]*types.Group, error)
+SyncGroupMembers(ctx context.Context, groupID string, userIDs []string) error
+```
+
+### CLI usage
+
+```bash
+# Remove a user from all groups
+hook-service users delete alice@example.com --dsn "postgres://..."
+
+# List groups for a user (JSON output)
+hook-service users list-groups alice@example.com --dsn "postgres://..." --format json
+
+# Replace a user's group memberships
+hook-service users set-groups alice@example.com --group group-id-1 --group group-id-2 --dsn "postgres://..."
+
+# Add users to a group
+hook-service groups add-users group-id-1 --user alice@example.com --user bob@example.com --dsn "postgres://..."
+
+# Run sync (reconcile DB with Salesforce)
+hook-service import --driver salesforce --sync --dsn "postgres://..." \
+  --domain sf.example.com --consumer-key KEY --consumer-secret SECRET
+```

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -7,6 +7,8 @@ This directory contains Architecture Decision Records documenting key technical 
 | ADR | Title | Status | Date |
 |-----|-------|--------|------|
 | [001](./001-remove-salesforce-integration.md) | Remove Salesforce Integration | Accepted | 2026-02-25 |
+| [002](./002-tenant-service-integration.md) | Tenant Service Integration | Accepted | 2026-03-12 |
+| [003](./003-cli-user-group-sync.md) | CLI User/Group Operations and Import Sync Mode | Accepted | 2026-05-04 |
 
 ## ADR Format
 

--- a/internal/importer/importer.go
+++ b/internal/importer/importer.go
@@ -17,6 +17,9 @@ type StorageInterface interface {
 	CreateGroup(ctx context.Context, group *types.Group) (*types.Group, error)
 	GetGroupByName(ctx context.Context, name, tenantID string) (*types.Group, error)
 	AddUsersToGroup(ctx context.Context, groupID string, userIDs []string) error
+	ListGroupsByPrefix(ctx context.Context, prefix, tenantID string) ([]*types.Group, error)
+	SyncGroupMembers(ctx context.Context, groupID string, userIDs []string) error
+	DeleteGroup(ctx context.Context, id string) error
 }
 
 // Importer handles the bulk import of user-group mappings from an external
@@ -24,14 +27,16 @@ type StorageInterface interface {
 type Importer struct {
 	driver  DriverInterface
 	storage StorageInterface
+	authz   AuthorizerInterface
 	logger  logging.LoggerInterface
 }
 
-// NewImporter creates a new Importer with the given driver, storage, and logger.
-func NewImporter(driver DriverInterface, storage StorageInterface, logger logging.LoggerInterface) *Importer {
+// NewImporter creates a new Importer with the given driver, storage, authz, and logger.
+func NewImporter(driver DriverInterface, storage StorageInterface, authz AuthorizerInterface, logger logging.LoggerInterface) *Importer {
 	return &Importer{
 		driver:  driver,
 		storage: storage,
+		authz:   authz,
 		logger:  logger,
 	}
 }
@@ -81,5 +86,96 @@ func (i *Importer) Run(ctx context.Context) error {
 	}
 
 	i.logger.Infof("Import complete: %d groups processed", created)
+	return nil
+}
+
+// Sync reconciles the database with the current state of the external driver.
+// It only affects groups prefixed with the driver's prefix — local/admin-created
+// groups are never touched. Groups present in the driver but not the DB are created;
+// groups present in the driver and DB are member-reconciled; groups present in the
+// DB but not the driver are deleted.
+func (i *Importer) Sync(ctx context.Context) error {
+	mappings, err := i.driver.FetchAllUserGroups(ctx)
+	if err != nil {
+		return fmt.Errorf("failed to fetch user groups from driver: %w", err)
+	}
+
+	i.logger.Infof("Fetched %d user-group mappings from driver for sync", len(mappings))
+
+	prefix := i.driver.Prefix()
+
+	// Build driverGroups: prefixed group name → []userID
+	driverGroups := make(map[string][]string)
+	for _, m := range mappings {
+		name := fmt.Sprintf("%s:%s", prefix, m.GroupName)
+		driverGroups[name] = append(driverGroups[name], m.UserID)
+	}
+
+	// Fetch existing groups matching the driver prefix from DB
+	existingGroups, err := i.storage.ListGroupsByPrefix(ctx, prefix+":", storage.DefaultTenantID)
+	if err != nil {
+		return fmt.Errorf("failed to list existing groups by prefix: %v", err)
+	}
+
+	// Build O(1) lookup map: name → *Group
+	existingByName := make(map[string]*types.Group, len(existingGroups))
+	for _, g := range existingGroups {
+		existingByName[g.Name] = g
+	}
+
+	synced, created, deleted := 0, 0, 0
+	failures := 0
+
+	// Reconcile driver groups against DB
+	for name, userIDs := range driverGroups {
+		if existing, ok := existingByName[name]; ok {
+			if err := i.storage.SyncGroupMembers(ctx, existing.ID, userIDs); err != nil {
+				i.logger.Errorf("Failed to sync members for group %q: %v", name, err)
+				failures++
+				continue
+			}
+			synced++
+			i.logger.Infof("Synced group %q with %d users", name, len(userIDs))
+		} else {
+			group, err := i.storage.CreateGroup(ctx, &types.Group{
+				Name:     name,
+				TenantId: storage.DefaultTenantID,
+			})
+			if err != nil {
+				i.logger.Errorf("Failed to create group %q: %v", name, err)
+				failures++
+				continue
+			}
+			if err := i.storage.AddUsersToGroup(ctx, group.ID, userIDs); err != nil {
+				i.logger.Errorf("Failed to add %d users to group %q: %v", len(userIDs), name, err)
+				failures++
+				continue
+			}
+			created++
+			i.logger.Infof("Created group %q with %d users", name, len(userIDs))
+		}
+	}
+
+	// Delete stale groups (present in DB but not in driver data)
+	for name, group := range existingByName {
+		if _, ok := driverGroups[name]; !ok {
+			if err := i.storage.DeleteGroup(ctx, group.ID); err != nil {
+				i.logger.Errorf("Failed to delete stale group %q: %v", name, err)
+				failures++
+				continue
+			}
+			if err := i.authz.DeleteGroup(ctx, group.ID); err != nil {
+				i.logger.Errorf("Failed to remove authorization tuples for stale group %q: %v", name, err)
+				failures++
+			}
+			deleted++
+			i.logger.Infof("Deleted stale group %q", name)
+		}
+	}
+
+	i.logger.Infof("Sync complete: %d synced, %d created, %d deleted", synced, created, deleted)
+	if failures > 0 {
+		return fmt.Errorf("sync completed with %d failure(s); see logs for details", failures)
+	}
 	return nil
 }

--- a/internal/importer/importer_test.go
+++ b/internal/importer/importer_test.go
@@ -35,12 +35,12 @@ import (
 func TestImporterRun(t *testing.T) {
 	tests := []struct {
 		name       string
-		setupMocks func(*MockDriverInterface, *MockStorageInterface, *MockLoggerInterface)
+		setupMocks func(*MockDriverInterface, *MockStorageInterface, *MockAuthorizerInterface, *MockLoggerInterface)
 		expectErr  bool
 	}{
 		{
 			name: "successful import",
-			setupMocks: func(driver *MockDriverInterface, store *MockStorageInterface, logger *MockLoggerInterface) {
+			setupMocks: func(driver *MockDriverInterface, store *MockStorageInterface, authz *MockAuthorizerInterface, logger *MockLoggerInterface) {
 				driver.EXPECT().Prefix().Return("salesforce").AnyTimes()
 				driver.EXPECT().FetchAllUserGroups(gomock.Any()).Return([]UserGroupMapping{
 					{UserID: "alice@example.com", GroupName: "Engineering"},
@@ -63,14 +63,14 @@ func TestImporterRun(t *testing.T) {
 		},
 		{
 			name: "driver error propagates",
-			setupMocks: func(driver *MockDriverInterface, store *MockStorageInterface, logger *MockLoggerInterface) {
+			setupMocks: func(driver *MockDriverInterface, store *MockStorageInterface, authz *MockAuthorizerInterface, logger *MockLoggerInterface) {
 				driver.EXPECT().FetchAllUserGroups(gomock.Any()).Return(nil, errors.New("salesforce unavailable"))
 			},
 			expectErr: true,
 		},
 		{
 			name: "empty mappings",
-			setupMocks: func(driver *MockDriverInterface, store *MockStorageInterface, logger *MockLoggerInterface) {
+			setupMocks: func(driver *MockDriverInterface, store *MockStorageInterface, authz *MockAuthorizerInterface, logger *MockLoggerInterface) {
 				driver.EXPECT().Prefix().Return("salesforce").AnyTimes()
 				driver.EXPECT().FetchAllUserGroups(gomock.Any()).Return([]UserGroupMapping{}, nil)
 				logger.EXPECT().Infof(gomock.Any(), gomock.Any()).AnyTimes()
@@ -78,7 +78,7 @@ func TestImporterRun(t *testing.T) {
 		},
 		{
 			name: "create group error is non-fatal",
-			setupMocks: func(driver *MockDriverInterface, store *MockStorageInterface, logger *MockLoggerInterface) {
+			setupMocks: func(driver *MockDriverInterface, store *MockStorageInterface, authz *MockAuthorizerInterface, logger *MockLoggerInterface) {
 				driver.EXPECT().Prefix().Return("salesforce").AnyTimes()
 				driver.EXPECT().FetchAllUserGroups(gomock.Any()).Return([]UserGroupMapping{
 					{UserID: "alice@example.com", GroupName: "Engineering"},
@@ -100,11 +100,12 @@ func TestImporterRun(t *testing.T) {
 
 			mockDriver := NewMockDriverInterface(ctrl)
 			mockStorage := NewMockStorageInterface(ctrl)
+			mockAuthz := NewMockAuthorizerInterface(ctrl)
 			mockLogger := NewMockLoggerInterface(ctrl)
 
-			tt.setupMocks(mockDriver, mockStorage, mockLogger)
+			tt.setupMocks(mockDriver, mockStorage, mockAuthz, mockLogger)
 
-			imp := NewImporter(mockDriver, mockStorage, mockLogger)
+			imp := NewImporter(mockDriver, mockStorage, mockAuthz, mockLogger)
 			err := imp.Run(context.Background())
 
 			if tt.expectErr && err == nil {
@@ -263,7 +264,8 @@ func TestImporterIntegration(t *testing.T) {
 		{UserID: "charlie@example.com", GroupName: "Sales"},
 	}, nil).AnyTimes()
 
-	imp := NewImporter(mockDriver, s, mockLogger)
+	mockAuthz := NewMockAuthorizerInterface(ctrl)
+	imp := NewImporter(mockDriver, s, mockAuthz, mockLogger)
 	if err := imp.Run(ctx); err != nil {
 		t.Fatalf("Import failed: %v", err)
 	}
@@ -309,5 +311,310 @@ func TestImporterIntegration(t *testing.T) {
 	}
 	if len(groupsAfterSecondRun) != len(groups) {
 		t.Fatalf("Expected group count to remain %d, got %d", len(groups), len(groupsAfterSecondRun))
+	}
+}
+
+func TestImporterSync(t *testing.T) {
+	tests := []struct {
+		name       string
+		setupMocks func(*MockDriverInterface, *MockStorageInterface, *MockAuthorizerInterface, *MockLoggerInterface)
+		expectErr  bool
+	}{
+		{
+			name: "successful sync - new groups created",
+			setupMocks: func(driver *MockDriverInterface, store *MockStorageInterface, authz *MockAuthorizerInterface, logger *MockLoggerInterface) {
+				driver.EXPECT().Prefix().Return("salesforce").AnyTimes()
+				driver.EXPECT().FetchAllUserGroups(gomock.Any()).Return([]UserGroupMapping{
+					{UserID: "alice@example.com", GroupName: "Engineering"},
+					{UserID: "bob@example.com", GroupName: "Engineering"},
+				}, nil)
+
+				logger.EXPECT().Infof(gomock.Any(), gomock.Any()).AnyTimes()
+				logger.EXPECT().Infof(gomock.Any(), gomock.Any(), gomock.Any()).AnyTimes()
+				logger.EXPECT().Infof(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).AnyTimes()
+
+				// No existing groups for this prefix
+				store.EXPECT().ListGroupsByPrefix(gomock.Any(), "salesforce:", storage.DefaultTenantID).Return(nil, nil)
+
+				// Group doesn't exist — create it
+				store.EXPECT().CreateGroup(gomock.Any(), gomock.Any()).Return(
+					&types.Group{ID: "g1", Name: "salesforce:Engineering"}, nil,
+				)
+				store.EXPECT().AddUsersToGroup(gomock.Any(), "g1", gomock.Any()).Return(nil)
+			},
+		},
+		{
+			name: "successful sync - existing group members reconciled",
+			setupMocks: func(driver *MockDriverInterface, store *MockStorageInterface, authz *MockAuthorizerInterface, logger *MockLoggerInterface) {
+				driver.EXPECT().Prefix().Return("salesforce").AnyTimes()
+				driver.EXPECT().FetchAllUserGroups(gomock.Any()).Return([]UserGroupMapping{
+					{UserID: "alice@example.com", GroupName: "Engineering"},
+				}, nil)
+
+				logger.EXPECT().Infof(gomock.Any(), gomock.Any()).AnyTimes()
+				logger.EXPECT().Infof(gomock.Any(), gomock.Any(), gomock.Any()).AnyTimes()
+				logger.EXPECT().Infof(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).AnyTimes()
+
+				store.EXPECT().ListGroupsByPrefix(gomock.Any(), "salesforce:", storage.DefaultTenantID).Return([]*types.Group{
+					{ID: "g1", Name: "salesforce:Engineering"},
+				}, nil)
+
+				store.EXPECT().SyncGroupMembers(gomock.Any(), "g1", gomock.Any()).Return(nil)
+			},
+		},
+		{
+			name: "successful sync - stale groups deleted",
+			setupMocks: func(driver *MockDriverInterface, store *MockStorageInterface, authz *MockAuthorizerInterface, logger *MockLoggerInterface) {
+				driver.EXPECT().Prefix().Return("salesforce").AnyTimes()
+				driver.EXPECT().FetchAllUserGroups(gomock.Any()).Return([]UserGroupMapping{}, nil)
+
+				logger.EXPECT().Infof(gomock.Any(), gomock.Any()).AnyTimes()
+				logger.EXPECT().Infof(gomock.Any(), gomock.Any(), gomock.Any()).AnyTimes()
+				logger.EXPECT().Infof(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).AnyTimes()
+
+				store.EXPECT().ListGroupsByPrefix(gomock.Any(), "salesforce:", storage.DefaultTenantID).Return([]*types.Group{
+					{ID: "g1", Name: "salesforce:OldTeam"},
+				}, nil)
+
+				store.EXPECT().DeleteGroup(gomock.Any(), "g1").Return(nil)
+				authz.EXPECT().DeleteGroup(gomock.Any(), "g1").Return(nil)
+			},
+		},
+		{
+			name: "driver error propagates",
+			setupMocks: func(driver *MockDriverInterface, store *MockStorageInterface, authz *MockAuthorizerInterface, logger *MockLoggerInterface) {
+				driver.EXPECT().FetchAllUserGroups(gomock.Any()).Return(nil, errors.New("salesforce unavailable"))
+			},
+			expectErr: true,
+		},
+		{
+			name: "list groups prefix error propagates",
+			setupMocks: func(driver *MockDriverInterface, store *MockStorageInterface, authz *MockAuthorizerInterface, logger *MockLoggerInterface) {
+				driver.EXPECT().Prefix().Return("salesforce").AnyTimes()
+				driver.EXPECT().FetchAllUserGroups(gomock.Any()).Return([]UserGroupMapping{}, nil)
+
+				logger.EXPECT().Infof(gomock.Any(), gomock.Any()).AnyTimes()
+
+				store.EXPECT().ListGroupsByPrefix(gomock.Any(), "salesforce:", storage.DefaultTenantID).Return(nil, errors.New("db error"))
+			},
+			expectErr: true,
+		},
+		{
+			name: "create group error is non-fatal per group but returns error",
+			setupMocks: func(driver *MockDriverInterface, store *MockStorageInterface, authz *MockAuthorizerInterface, logger *MockLoggerInterface) {
+				driver.EXPECT().Prefix().Return("salesforce").AnyTimes()
+				driver.EXPECT().FetchAllUserGroups(gomock.Any()).Return([]UserGroupMapping{
+					{UserID: "alice@example.com", GroupName: "Engineering"},
+				}, nil)
+
+				logger.EXPECT().Infof(gomock.Any(), gomock.Any()).AnyTimes()
+				logger.EXPECT().Infof(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).AnyTimes()
+				logger.EXPECT().Errorf(gomock.Any(), gomock.Any(), gomock.Any()).AnyTimes()
+
+				store.EXPECT().ListGroupsByPrefix(gomock.Any(), "salesforce:", storage.DefaultTenantID).Return(nil, nil)
+				store.EXPECT().CreateGroup(gomock.Any(), gomock.Any()).Return(nil, errors.New("db error"))
+			},
+			expectErr: true,
+		},
+		{
+			name: "sync members error is non-fatal per group but returns error",
+			setupMocks: func(driver *MockDriverInterface, store *MockStorageInterface, authz *MockAuthorizerInterface, logger *MockLoggerInterface) {
+				driver.EXPECT().Prefix().Return("salesforce").AnyTimes()
+				driver.EXPECT().FetchAllUserGroups(gomock.Any()).Return([]UserGroupMapping{
+					{UserID: "alice@example.com", GroupName: "Engineering"},
+				}, nil)
+
+				logger.EXPECT().Infof(gomock.Any(), gomock.Any()).AnyTimes()
+				logger.EXPECT().Infof(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).AnyTimes()
+				logger.EXPECT().Errorf(gomock.Any(), gomock.Any(), gomock.Any()).AnyTimes()
+
+				store.EXPECT().ListGroupsByPrefix(gomock.Any(), "salesforce:", storage.DefaultTenantID).Return([]*types.Group{
+					{ID: "g1", Name: "salesforce:Engineering"},
+				}, nil)
+				store.EXPECT().SyncGroupMembers(gomock.Any(), "g1", gomock.Any()).Return(errors.New("db error"))
+			},
+			expectErr: true,
+		},
+		{
+			name: "delete stale group error is non-fatal per group but returns error",
+			setupMocks: func(driver *MockDriverInterface, store *MockStorageInterface, authz *MockAuthorizerInterface, logger *MockLoggerInterface) {
+				driver.EXPECT().Prefix().Return("salesforce").AnyTimes()
+				driver.EXPECT().FetchAllUserGroups(gomock.Any()).Return([]UserGroupMapping{}, nil)
+
+				logger.EXPECT().Infof(gomock.Any(), gomock.Any()).AnyTimes()
+				logger.EXPECT().Infof(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).AnyTimes()
+				logger.EXPECT().Errorf(gomock.Any(), gomock.Any(), gomock.Any()).AnyTimes()
+
+				store.EXPECT().ListGroupsByPrefix(gomock.Any(), "salesforce:", storage.DefaultTenantID).Return([]*types.Group{
+					{ID: "g1", Name: "salesforce:OldTeam"},
+				}, nil)
+				store.EXPECT().DeleteGroup(gomock.Any(), "g1").Return(errors.New("db error"))
+			},
+			expectErr: true,
+		},
+		{
+			name: "partial failure error message contains failure count",
+			setupMocks: func(driver *MockDriverInterface, store *MockStorageInterface, authz *MockAuthorizerInterface, logger *MockLoggerInterface) {
+				driver.EXPECT().Prefix().Return("salesforce").AnyTimes()
+				driver.EXPECT().FetchAllUserGroups(gomock.Any()).Return([]UserGroupMapping{
+					{UserID: "alice@example.com", GroupName: "Engineering"},
+				}, nil)
+
+				logger.EXPECT().Infof(gomock.Any(), gomock.Any()).AnyTimes()
+				logger.EXPECT().Infof(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).AnyTimes()
+				logger.EXPECT().Errorf(gomock.Any(), gomock.Any(), gomock.Any()).AnyTimes()
+
+				store.EXPECT().ListGroupsByPrefix(gomock.Any(), "salesforce:", storage.DefaultTenantID).Return(nil, nil)
+				store.EXPECT().CreateGroup(gomock.Any(), gomock.Any()).Return(nil, errors.New("db error"))
+			},
+			expectErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctrl := gomock.NewController(t)
+			defer ctrl.Finish()
+
+			mockDriver := NewMockDriverInterface(ctrl)
+			mockStorage := NewMockStorageInterface(ctrl)
+			mockAuthz := NewMockAuthorizerInterface(ctrl)
+			mockLogger := NewMockLoggerInterface(ctrl)
+
+			tt.setupMocks(mockDriver, mockStorage, mockAuthz, mockLogger)
+
+			imp := NewImporter(mockDriver, mockStorage, mockAuthz, mockLogger)
+			err := imp.Sync(context.Background())
+
+			if tt.expectErr && err == nil {
+				t.Fatal("expected error, got nil")
+			}
+			if !tt.expectErr && err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+		})
+	}
+}
+
+func TestImporterSyncIntegration(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping integration test in short mode")
+	}
+
+	t.Parallel()
+
+	connStr, container := setupTestPostgres(t)
+	if container == nil {
+		return // skipped due to Docker unavailability
+	}
+	defer func() {
+		if err := container.Terminate(context.Background()); err != nil {
+			t.Logf("Failed to terminate container: %v", err)
+		}
+	}()
+
+	runMigrations(t, connStr)
+
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mockTracer := NewMockTracingInterface(ctrl)
+	mockMonitor := NewMockMonitorInterface(ctrl)
+	mockLogger := NewMockLoggerInterface(ctrl)
+
+	mockLogger.EXPECT().Infof(gomock.Any(), gomock.Any()).Do(func(f string, v ...interface{}) { t.Logf("INFO: "+f, v...) }).AnyTimes()
+	mockLogger.EXPECT().Infof(gomock.Any(), gomock.Any(), gomock.Any()).Do(func(f string, v ...interface{}) { t.Logf("INFO: "+f, v...) }).AnyTimes()
+	mockLogger.EXPECT().Infof(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Do(func(f string, v ...interface{}) { t.Logf("INFO: "+f, v...) }).AnyTimes()
+	mockLogger.EXPECT().Errorf(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Do(func(f string, v ...interface{}) { t.Logf("ERROR: "+f, v...) }).AnyTimes()
+	mockLogger.EXPECT().Debugf(gomock.Any(), gomock.Any()).Do(func(f string, v ...interface{}) { t.Logf("DEBUG: "+f, v...) }).AnyTimes()
+	mockLogger.EXPECT().Warnf(gomock.Any(), gomock.Any()).Do(func(f string, v ...interface{}) { t.Logf("WARN: "+f, v...) }).AnyTimes()
+	mockLogger.EXPECT().Fatalf(gomock.Any(), gomock.Any()).Do(func(f string, v ...interface{}) { t.Logf("FATAL: "+f, v...) }).AnyTimes()
+	mockTracer.EXPECT().Start(gomock.Any(), gomock.Any()).Return(context.Background(), trace.SpanFromContext(context.Background())).AnyTimes()
+
+	dbClient, err := db.NewDBClient(
+		db.Config{DSN: connStr, MinConns: 10, MaxConns: 20},
+		mockTracer,
+		mockMonitor,
+		mockLogger,
+	)
+	if err != nil {
+		t.Fatalf("Failed to create DB client: %v", err)
+	}
+	defer dbClient.Close()
+
+	ctx := context.Background()
+	s := storage.NewStorage(dbClient, mockTracer, mockMonitor, mockLogger)
+
+	mockDriver := NewMockDriverInterface(ctrl)
+	mockDriver.EXPECT().Prefix().Return("salesforce").AnyTimes()
+
+	// Phase 1: initial import via Run
+	mockDriver.EXPECT().FetchAllUserGroups(gomock.Any()).Return([]UserGroupMapping{
+		{UserID: "alice@example.com", GroupName: "Engineering"},
+		{UserID: "bob@example.com", GroupName: "Engineering"},
+		{UserID: "alice@example.com", GroupName: "Platform"},
+		{UserID: "charlie@example.com", GroupName: "Sales"},
+	}, nil).Times(1)
+
+	mockAuthz := NewMockAuthorizerInterface(ctrl)
+	mockAuthz.EXPECT().DeleteGroup(gomock.Any(), gomock.Any()).Return(nil).AnyTimes()
+	imp := NewImporter(mockDriver, s, mockAuthz, mockLogger)
+	if err := imp.Run(ctx); err != nil {
+		t.Fatalf("Initial import failed: %v", err)
+	}
+
+	groupsAfterImport, err := s.ListGroups(ctx)
+	if err != nil {
+		t.Fatalf("Failed to list groups after import: %v", err)
+	}
+	if len(groupsAfterImport) != 3 {
+		t.Fatalf("Expected 3 groups after import, got %d", len(groupsAfterImport))
+	}
+
+	// Phase 2: sync — bob leaves Engineering, Sales is removed, Marketing is added
+	mockDriver.EXPECT().FetchAllUserGroups(gomock.Any()).Return([]UserGroupMapping{
+		{UserID: "alice@example.com", GroupName: "Engineering"},
+		{UserID: "alice@example.com", GroupName: "Platform"},
+		{UserID: "dave@example.com", GroupName: "Marketing"},
+	}, nil).Times(1)
+
+	if err := imp.Sync(ctx); err != nil {
+		t.Fatalf("Sync failed: %v", err)
+	}
+
+	groupsAfterSync, err := s.ListGroups(ctx)
+	if err != nil {
+		t.Fatalf("Failed to list groups after sync: %v", err)
+	}
+	// Engineering, Platform, Marketing — Sales deleted
+	if len(groupsAfterSync) != 3 {
+		t.Fatalf("Expected 3 groups after sync, got %d: %v", len(groupsAfterSync), groupsAfterSync)
+	}
+
+	// bob should no longer be in Engineering
+	bobGroups, err := s.GetGroupsForUser(ctx, "bob@example.com")
+	if err != nil {
+		t.Fatalf("Failed to get groups for bob: %v", err)
+	}
+	if len(bobGroups) != 0 {
+		t.Fatalf("Expected bob to be in 0 groups after sync, got %d", len(bobGroups))
+	}
+
+	// dave should be in Marketing
+	daveGroups, err := s.GetGroupsForUser(ctx, "dave@example.com")
+	if err != nil {
+		t.Fatalf("Failed to get groups for dave: %v", err)
+	}
+	if len(daveGroups) != 1 {
+		t.Fatalf("Expected dave to be in 1 group after sync, got %d", len(daveGroups))
+	}
+
+	// alice should still be in 2 groups
+	aliceGroups, err := s.GetGroupsForUser(ctx, "alice@example.com")
+	if err != nil {
+		t.Fatalf("Failed to get groups for alice: %v", err)
+	}
+	if len(aliceGroups) != 2 {
+		t.Fatalf("Expected alice to be in 2 groups after sync, got %d", len(aliceGroups))
 	}
 }

--- a/internal/importer/interfaces.go
+++ b/internal/importer/interfaces.go
@@ -17,3 +17,9 @@ type DriverInterface interface {
 	Prefix() string
 	FetchAllUserGroups(ctx context.Context) ([]UserGroupMapping, error)
 }
+
+// AuthorizerInterface defines the authorization side-effects required by the Importer.
+// DeleteGroup removes all authorization tuples associated with a group when it is deleted.
+type AuthorizerInterface interface {
+	DeleteGroup(ctx context.Context, id string) error
+}

--- a/internal/storage/groups.go
+++ b/internal/storage/groups.go
@@ -10,6 +10,7 @@ import (
 	"fmt"
 	"maps"
 	"slices"
+	"strings"
 	"time"
 
 	sq "github.com/Masterminds/squirrel"
@@ -197,20 +198,31 @@ func (s *Storage) AddUsersToGroup(ctx context.Context, groupID string, userIDs [
 		return nil
 	}
 
+	// Deduplicate userIDs to avoid the "ON CONFLICT DO UPDATE command cannot
+	// affect row a second time" PostgreSQL error when duplicates are in the
+	// input slice.
+	seen := make(map[string]struct{}, len(userIDs))
+	unique := make([]string, 0, len(userIDs))
+	for _, id := range userIDs {
+		if _, ok := seen[id]; !ok {
+			seen[id] = struct{}{}
+			unique = append(unique, id)
+		}
+	}
+
 	now := time.Now().UTC()
 	insert := s.db.Statement(ctx).
 		Insert("group_members").
 		Columns("group_id", "user_id", "tenant_id", "role", "created_at", "updated_at")
 
-	for _, userID := range userIDs {
+	for _, userID := range unique {
 		insert = insert.Values(groupID, userID, "default", types.RoleMember, now, now)
 	}
 
-	_, err := insert.ExecContext(ctx)
+	_, err := insert.
+		Suffix("ON CONFLICT (group_id, user_id) DO UPDATE SET updated_at = EXCLUDED.updated_at").
+		ExecContext(ctx)
 	if err != nil {
-		if IsDuplicateKeyError(err) {
-			return WrapDuplicateKeyError(err, "user already in group")
-		}
 		if IsForeignKeyViolation(err) {
 			return WrapForeignKeyError(err, "group does not exist")
 		}
@@ -348,6 +360,113 @@ func (s *Storage) UpdateGroupsForUser(ctx context.Context, userID string, groupI
 			return WrapForeignKeyError(err, "one or more groups do not exist")
 		}
 		return fmt.Errorf("failed to upsert group memberships: %v", err)
+	}
+
+	return nil
+}
+
+// RemoveUserFromAllGroups removes a user from every group they belong to.
+// This operation is idempotent — it succeeds even if the user has no memberships.
+func (s *Storage) RemoveUserFromAllGroups(ctx context.Context, userID string) error {
+	ctx, span := s.tracer.Start(ctx, "storage.Storage.RemoveUserFromAllGroups")
+	defer span.End()
+
+	_, err := s.db.Statement(ctx).
+		Delete("group_members").
+		Where(sq.Eq{"user_id": userID}).
+		ExecContext(ctx)
+	if err != nil {
+		return fmt.Errorf("failed to remove user from all groups: %v", err)
+	}
+
+	return nil
+}
+
+// ListGroupsByPrefix retrieves all groups whose names start with the given prefix for a tenant.
+// It uses a LIKE query with an escaped prefix for correctness across all PostgreSQL collations.
+// (A lexicographic byte-range approach does not work correctly with non-C locales such as
+// en_US.UTF-8, where letters sort differently relative to punctuation characters.)
+func (s *Storage) ListGroupsByPrefix(ctx context.Context, prefix, tenantID string) ([]*types.Group, error) {
+	ctx, span := s.tracer.Start(ctx, "storage.Storage.ListGroupsByPrefix")
+	defer span.End()
+
+	if tenantID == "" {
+		tenantID = DefaultTenantID
+	}
+
+	escaped := strings.NewReplacer(`\`, `\\`, `%`, `\%`, `_`, `\_`).Replace(prefix)
+	rows, err := s.db.Statement(ctx).
+		Select("id", "name", "tenant_id", "description", "type", "created_at", "updated_at").
+		From("groups").
+		Where(sq.Eq{"tenant_id": tenantID}).
+		Where(sq.Expr("name LIKE ? ESCAPE '\\'", escaped+"%")).
+		OrderBy("name ASC").
+		QueryContext(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("failed to query groups by prefix: %v", err)
+	}
+	defer rows.Close()
+
+	groups := make([]*types.Group, 0)
+	for rows.Next() {
+		group, err := scanGroup(rows)
+		if err != nil {
+			return nil, fmt.Errorf("failed to scan group: %v", err)
+		}
+		groups = append(groups, group)
+	}
+
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("error iterating groups: %v", err)
+	}
+
+	return groups, nil
+}
+
+// SyncGroupMembers replaces all memberships of a group with the provided user IDs.
+// It deduplicates the provided user IDs, removes members not in the list,
+// and upserts the current members. This mirrors UpdateGroupsForUser but is group-centric.
+func (s *Storage) SyncGroupMembers(ctx context.Context, groupID string, userIDs []string) error {
+	ctx, span := s.tracer.Start(ctx, "storage.Storage.SyncGroupMembers")
+	defer span.End()
+
+	// Deduplicate userIDs to avoid PostgreSQL error: "ON CONFLICT DO UPDATE command cannot affect row a second time"
+	uniqueUserIDsMap := make(map[string]struct{}, len(userIDs))
+	for _, id := range userIDs {
+		uniqueUserIDsMap[id] = struct{}{}
+	}
+	uniqueUserIDs := slices.Collect(maps.Keys(uniqueUserIDsMap))
+
+	// Remove members that are not in the provided list
+	delBuilder := s.db.Statement(ctx).
+		Delete("group_members").
+		Where(sq.Eq{"group_id": groupID})
+
+	if len(uniqueUserIDs) > 0 {
+		delBuilder = delBuilder.Where(sq.NotEq{"user_id": uniqueUserIDs})
+	}
+
+	if _, err := delBuilder.ExecContext(ctx); err != nil {
+		return fmt.Errorf("failed to remove stale group members: %v", err)
+	}
+
+	if len(uniqueUserIDs) == 0 {
+		return nil
+	}
+
+	now := time.Now().UTC()
+
+	insert := s.db.Statement(ctx).
+		Insert("group_members").
+		Columns("group_id", "user_id", "tenant_id", "role", "created_at", "updated_at").
+		Suffix("ON CONFLICT (group_id, user_id) DO UPDATE SET updated_at = EXCLUDED.updated_at")
+
+	for _, userID := range uniqueUserIDs {
+		insert = insert.Values(groupID, userID, "default", types.RoleMember, now, now)
+	}
+
+	if _, err := insert.ExecContext(ctx); err != nil {
+		return fmt.Errorf("failed to upsert group members: %v", err)
 	}
 
 	return nil

--- a/internal/storage/interfaces.go
+++ b/internal/storage/interfaces.go
@@ -26,6 +26,11 @@ type StorageInterface interface {
 	// User-centric group operations
 	GetGroupsForUser(ctx context.Context, userID string) ([]*types.Group, error)
 	UpdateGroupsForUser(ctx context.Context, userID string, groupIDs []string) error
+	RemoveUserFromAllGroups(ctx context.Context, userID string) error
+
+	// Prefix-based group operations
+	ListGroupsByPrefix(ctx context.Context, prefix, tenantID string) ([]*types.Group, error)
+	SyncGroupMembers(ctx context.Context, groupID string, userIDs []string) error
 
 	// Application authorization operations
 	GetAllowedApps(ctx context.Context, groupID string) ([]string, error)

--- a/openspec/changes/archive/2026-06-01-cli-user-group-sync/.openspec.yaml
+++ b/openspec/changes/archive/2026-06-01-cli-user-group-sync/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-06-01

--- a/openspec/changes/archive/2026-06-01-cli-user-group-sync/design.md
+++ b/openspec/changes/archive/2026-06-01-cli-user-group-sync/design.md
@@ -1,0 +1,65 @@
+## Context
+
+The hook-service manages user-group memberships in PostgreSQL and uses OpenFGA for fine-grained authorization. The service exposes group operations via a gRPC API, but there is no command-line path for operators to inspect or repair group state, and the existing `import` command (which bulk-loads Salesforce data) can only add — it cannot remove groups that the provider has dropped.
+
+The branch introduces two new CLI command trees (`users`, `groups`) and a `--sync` reconciliation mode on `import`. A code review identified several correctness and safety issues alongside the new features.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Define what the new `users` and `groups` CLI commands must do and how they must behave safely
+- Define the `import --sync` reconciliation contract including OpenFGA side-effects
+- Establish correctness requirements for `ListGroupsByPrefix` (LIKE escaping), partial-failure signalling in `Sync`, context propagation, and input validation
+
+**Non-Goals:**
+- Exposing the new operations via the gRPC/HTTP API
+- Transaction atomicity for `Sync` (documented as a known trade-off)
+- Pagination for list operations
+
+## Decisions
+
+### D1: Direct-DB access for CLI commands (not via service layer)
+
+**Decision**: CLI commands call `storage.Storage` directly rather than the gRPC API.
+
+**Rationale**: The CLI is an operator tool, not a user-facing API. Requiring the service to be running adds operational complexity (credentials, network, auth tokens). The direct path is acceptable for all read and additive operations. The only operation with an out-of-DB side-effect is `DeleteGroup`, which additionally requires OpenFGA tuple cleanup.
+
+**Alternative considered**: Route everything through the gRPC API. Rejected because it requires the service to be up and adds auth complexity for a maintenance tool.
+
+**Boundary rule**: Whenever a CLI operation matches one that `pkg/groups.Service` performs with extra side-effects (currently only `DeleteGroup`), the CLI must replicate those side-effects (call the authorizer) or refuse to perform the operation.
+
+### D2: `AuthorizerInterface` injected into `Importer` (not full service)
+
+**Decision**: Add a narrow `AuthorizerInterface` (one method: `DeleteGroup`) to the `importer` package rather than injecting `pkg/groups.ServiceInterface`.
+
+**Rationale**: Injecting the full service would introduce a cross-package dependency that pulls in the entire service stack. The importer only needs to clean up authorization tuples on group deletion. A single-method interface keeps the dependency minimal and testable.
+
+**Authorizer wiring**: When `--openfga-host` is not set, `cmd/import.go` uses `openfga.NewNoopClient`, making OpenFGA cleanup a no-op (correct when authorization is disabled).
+
+### D3: `Sync` partial failures are non-fatal per group, but the function reports overall failure
+
+**Decision**: Per-group errors in `Sync` are logged and the loop continues (to maximize progress), but the function returns a non-nil error at the end if any operation failed.
+
+**Rationale**: Stopping on the first failure would leave many groups unprocessed for what may be a transient DB error. Silently returning `nil` makes CI pipelines unable to detect a broken sync. Logging each failure and returning an aggregate error at the end is the best trade-off.
+
+### D4: LIKE prefix escaping in `ListGroupsByPrefix`
+
+**Decision**: Escape `%`, `_`, and `\` in the prefix argument before constructing the LIKE clause, using PostgreSQL's `ESCAPE '\'` syntax.
+
+**Rationale**: The comment on the existing function claims escaping is applied — it is not. Any prefix containing wildcard characters would match unintended groups. While the current `SalesforceDriver` prefix (`salesforce`) is safe, the `DriverInterface` is open to extension.
+
+### D5: `cmd.Context()` for all CLI handlers
+
+**Decision**: All CLI handler functions use `cmd.Context()` rather than `context.Background()`.
+
+**Rationale**: Cobra propagates OS signals (SIGINT/SIGTERM) through `cmd.Context()`. Using `context.Background()` means Ctrl+C cannot cancel in-flight database operations.
+
+## Risks / Trade-offs
+
+- **Non-atomic Sync** → Mitigation: documented limitation; operators can re-run `--sync` safely because `SyncGroupMembers` is idempotent and `DeleteGroup` is idempotent. A future improvement could wrap the entire sync in a transaction via `db.WithTx`.
+- **OpenFGA failure after DB delete** → Mitigation: the authorizer failure is logged but does not roll back the DB delete. A future improvement could run the authorizer call first (fail-fast) before the DB delete.
+- **Direct DB write bypasses service validation** → Mitigation: acceptable for the identified operations; any new CLI operation that touches authz must follow the same pattern as `DeleteGroup`.
+
+## Open Questions
+
+(none — all questions resolved during design)

--- a/openspec/changes/archive/2026-06-01-cli-user-group-sync/proposal.md
+++ b/openspec/changes/archive/2026-06-01-cli-user-group-sync/proposal.md
@@ -1,0 +1,43 @@
+## Why
+
+Operators need to manage user-group memberships and reconcile external provider data (Salesforce) without running the full service. There is no mechanism today to inspect or correct group state directly from the command line, and the `import` command can only add data — it cannot remove stale groups when a provider removes them.
+
+## What Changes
+
+- **New CLI command `users`** with subcommands:
+  - `users delete <user-id>` — remove a user from all groups
+  - `users list-groups <user-id>` — list all groups a user belongs to
+  - `users set-groups <user-id>` — replace a user's group memberships
+- **New CLI command `groups`** with subcommands:
+  - `groups add-users <group-id>` — add one or more users to a group
+  - `groups remove-users <group-id>` — remove one or more users from a group
+  - `groups list-users <group-id>` — list all members of a group
+- **New `--sync` flag on the existing `import` command** — reconciles the database against the external driver, creating missing groups, syncing memberships, and deleting stale groups
+- **New storage methods**: `RemoveUserFromAllGroups`, `ListGroupsByPrefix`, `SyncGroupMembers`
+- **OpenFGA tuple cleanup on group deletion** — `Sync` now calls the authorizer to remove authorization tuples when it deletes a stale group, preventing privilege escalation via orphaned tuples
+- **Fix: LIKE wildcard escaping** in `ListGroupsByPrefix` — prefix is escaped before use in SQL `LIKE` to prevent incorrect matches
+- **Fix: `Sync` partial-failure reporting** — returns an error if any per-group operation fails rather than always returning `nil`
+- **Fix: signal-aware context** in all CLI handlers — use `cmd.Context()` instead of `context.Background()`
+- **Fix: input validation** — `--user` flag required on `groups add-users`; `--group` flag required on `users set-groups` to prevent accidental removal of all memberships
+- **Fix: SPDX identifiers** in new files corrected from `AGPL-3.0` to `AGPL-3.0-only`
+
+## Capabilities
+
+### New Capabilities
+
+- `cli-user-management`: Direct CLI management of user group memberships (delete, list-groups, set-groups)
+- `cli-group-management`: Direct CLI management of group members (add-users, remove-users, list-users)
+- `import-sync`: Reconciliation mode for the import command that removes stale driver-managed groups and their OpenFGA authorization tuples
+
+### Modified Capabilities
+
+(none — no existing spec files)
+
+## Impact
+
+- **`cmd/`**: two new files (`users.go`, `groups_cmd.go`) and modifications to `import.go`
+- **`internal/importer/`**: new `Sync()` method, new `AuthorizerInterface`, updated `NewImporter` signature
+- **`internal/storage/groups.go`**: three new methods added to `Storage` and `StorageInterface`
+- **`internal/storage/interfaces.go`**: `StorageInterface` extended
+- **No API surface change**: all new operations are CLI-only and bypass the gRPC API intentionally; the one exception is the authorizer call on group deletion which mirrors `pkg/groups.Service.DeleteGroup`
+- **Operators** require a PostgreSQL DSN (`--dsn`) for all new commands; `--openfga-host` is optional for `import --sync` to enable OpenFGA cleanup

--- a/openspec/changes/archive/2026-06-01-cli-user-group-sync/specs/cli-group-management/spec.md
+++ b/openspec/changes/archive/2026-06-01-cli-user-group-sync/specs/cli-group-management/spec.md
@@ -1,0 +1,58 @@
+## ADDED Requirements
+
+### Requirement: Add users to a group
+The CLI SHALL provide a `groups add-users <group-id>` subcommand that adds the specified users to a group. The `--user` flag SHALL be required and repeatable.
+
+#### Scenario: Users added
+- **WHEN** operator runs `groups add-users <group-id> --user <id1> --user <id2> --dsn <dsn>`
+- **THEN** the specified users are members of the group
+- **THEN** the command exits with code 0
+
+#### Scenario: Missing --user flag
+- **WHEN** operator runs `groups add-users <group-id> --dsn <dsn>` without any `--user` flag
+- **THEN** the command exits with a non-zero code and an error message
+
+#### Scenario: JSON output
+- **WHEN** operator runs `groups add-users <group-id> --user <id1> --dsn <dsn> --format json`
+- **THEN** the command outputs `{"group_id": "<group-id>", "users_added": 1}` as valid JSON
+
+### Requirement: Remove users from a group
+The CLI SHALL provide a `groups remove-users <group-id>` subcommand that removes the specified users from a group. The operation SHALL be idempotent.
+
+#### Scenario: Users removed
+- **WHEN** operator runs `groups remove-users <group-id> --user <id1> --dsn <dsn>`
+- **THEN** the specified users are no longer members of the group
+
+#### Scenario: User not in group
+- **WHEN** operator runs `groups remove-users <group-id> --user <id1> --dsn <dsn>` for a user not in the group
+- **THEN** the command exits with code 0 (idempotent)
+
+#### Scenario: JSON output
+- **WHEN** operator runs `groups remove-users <group-id> --user <id1> --dsn <dsn> --format json`
+- **THEN** the command outputs `{"group_id": "<group-id>", "users_removed": 1}` as valid JSON
+
+### Requirement: List users in a group
+The CLI SHALL provide a `groups list-users <group-id>` subcommand that prints all members of the specified group.
+
+#### Scenario: Group has members
+- **WHEN** operator runs `groups list-users <group-id> --dsn <dsn>`
+- **THEN** each user ID is printed on a separate line
+
+#### Scenario: Group has no members
+- **WHEN** operator runs `groups list-users <group-id> --dsn <dsn>` for an empty group
+- **THEN** the command exits with code 0 and prints nothing
+
+#### Scenario: JSON output
+- **WHEN** operator runs `groups list-users <group-id> --dsn <dsn> --format json`
+- **THEN** the command outputs a JSON array of user ID strings (empty array when no members)
+
+### Requirement: Exactly one positional argument required
+All `groups` subcommands SHALL require exactly one positional argument (the group ID).
+
+#### Scenario: No positional argument
+- **WHEN** operator runs a `groups` subcommand with no positional argument
+- **THEN** the command exits with a non-zero code
+
+#### Scenario: Extra positional argument
+- **WHEN** operator runs a `groups` subcommand with two positional arguments
+- **THEN** the command exits with a non-zero code

--- a/openspec/changes/archive/2026-06-01-cli-user-group-sync/specs/cli-user-management/spec.md
+++ b/openspec/changes/archive/2026-06-01-cli-user-group-sync/specs/cli-user-management/spec.md
@@ -1,0 +1,62 @@
+## ADDED Requirements
+
+### Requirement: Delete user from all groups
+The CLI SHALL provide a `users delete <user-id>` subcommand that removes the specified user from every group they belong to. The operation SHALL be idempotent — it succeeds even when the user has no memberships.
+
+#### Scenario: User deleted from all groups
+- **WHEN** operator runs `users delete <user-id> --dsn <dsn>`
+- **THEN** the user is removed from all groups in the database
+- **THEN** the command exits with code 0 and prints a confirmation message
+
+#### Scenario: User has no memberships
+- **WHEN** operator runs `users delete <user-id> --dsn <dsn>` for a user with no group memberships
+- **THEN** the command exits with code 0 (idempotent)
+
+#### Scenario: JSON output
+- **WHEN** operator runs `users delete <user-id> --dsn <dsn> --format json`
+- **THEN** the command outputs `{"user_id": "<user-id>", "status": "deleted"}` as valid JSON
+
+#### Scenario: Missing DSN
+- **WHEN** operator runs `users delete <user-id>` without `--dsn`
+- **THEN** the command exits with a non-zero code and an error message
+
+### Requirement: List groups for a user
+The CLI SHALL provide a `users list-groups <user-id>` subcommand that prints all groups the specified user belongs to.
+
+#### Scenario: User is in groups
+- **WHEN** operator runs `users list-groups <user-id> --dsn <dsn>`
+- **THEN** each group name is printed on a separate line
+
+#### Scenario: User is in no groups
+- **WHEN** operator runs `users list-groups <user-id> --dsn <dsn>` for a user with no memberships
+- **THEN** the command exits with code 0 and prints nothing
+
+#### Scenario: JSON output
+- **WHEN** operator runs `users list-groups <user-id> --dsn <dsn> --format json`
+- **THEN** the command outputs a JSON array of group objects (empty array when no memberships)
+
+### Requirement: Set groups for a user
+The CLI SHALL provide a `users set-groups <user-id>` subcommand that replaces the user's group memberships with the provided set. The `--group` flag SHALL be required to prevent accidental removal of all memberships.
+
+#### Scenario: Groups replaced
+- **WHEN** operator runs `users set-groups <user-id> --group <id1> --group <id2> --dsn <dsn>`
+- **THEN** the user belongs exactly to the specified groups
+
+#### Scenario: Missing --group flag
+- **WHEN** operator runs `users set-groups <user-id> --dsn <dsn>` without any `--group` flag
+- **THEN** the command exits with a non-zero code and an error message
+
+#### Scenario: Context cancellation
+- **WHEN** operator sends SIGINT while `users set-groups` is running
+- **THEN** the in-flight database operation is cancelled and the command exits with a non-zero code
+
+### Requirement: Exactly one positional argument required
+All `users` subcommands SHALL require exactly one positional argument (the user ID). Too few or too many arguments SHALL result in a non-zero exit code.
+
+#### Scenario: No positional argument
+- **WHEN** operator runs a `users` subcommand with no positional argument
+- **THEN** the command exits with a non-zero code
+
+#### Scenario: Extra positional argument
+- **WHEN** operator runs a `users` subcommand with two positional arguments
+- **THEN** the command exits with a non-zero code

--- a/openspec/changes/archive/2026-06-01-cli-user-group-sync/specs/import-sync/spec.md
+++ b/openspec/changes/archive/2026-06-01-cli-user-group-sync/specs/import-sync/spec.md
@@ -1,0 +1,84 @@
+## ADDED Requirements
+
+### Requirement: Reconcile database with driver data
+The `import` command SHALL accept a `--sync` flag that, when present, reconciles the database against the current state of the external driver instead of performing an additive-only import. Reconciliation MUST:
+- Create groups present in the driver but absent from the database
+- Sync memberships for groups present in both the driver and the database
+- Delete groups present in the database but absent from the driver (only those matching the driver's prefix)
+- Never modify groups that do not match the driver's prefix
+
+#### Scenario: New groups created
+- **WHEN** operator runs `import --sync --driver salesforce ...`
+- **AND** the driver returns a group that does not exist in the database
+- **THEN** the group and its members are created in the database
+
+#### Scenario: Existing group memberships reconciled
+- **WHEN** operator runs `import --sync --driver salesforce ...`
+- **AND** the driver returns a group that already exists in the database with different members
+- **THEN** the group's members are updated to exactly match the driver's list
+
+#### Scenario: Stale groups deleted
+- **WHEN** operator runs `import --sync --driver salesforce ...`
+- **AND** the database contains a prefixed group that is absent from the driver data
+- **THEN** the group is deleted from the database
+- **THEN** all OpenFGA authorization tuples for the deleted group are removed
+
+#### Scenario: Non-prefixed groups untouched
+- **WHEN** operator runs `import --sync --driver salesforce ...`
+- **AND** the database contains a group whose name does not start with `salesforce:`
+- **THEN** that group is not modified or deleted
+
+### Requirement: Partial failure reporting
+If one or more per-group operations fail during `--sync`, the `import` command SHALL exit with a non-zero exit code after completing all remaining operations. Individual failures SHALL be logged.
+
+#### Scenario: One group fails, others succeed
+- **WHEN** `import --sync` encounters a DB error for one group
+- **THEN** reconciliation continues for the remaining groups
+- **THEN** the command exits with a non-zero exit code
+
+#### Scenario: All groups succeed
+- **WHEN** `import --sync` completes all operations without error
+- **THEN** the command exits with code 0
+
+### Requirement: OpenFGA tuple cleanup on group deletion
+When `import --sync` deletes a stale group, it SHALL also remove all associated OpenFGA authorization tuples (via the authorizer). If `--openfga-host` is not provided, the cleanup step is skipped (noop authorizer).
+
+#### Scenario: Stale group deleted with OpenFGA configured
+- **WHEN** `import --sync` deletes a stale group
+- **AND** `--openfga-host` is set
+- **THEN** all OpenFGA tuples for that group are removed after the DB delete
+
+#### Scenario: Stale group deleted without OpenFGA configured
+- **WHEN** `import --sync` deletes a stale group
+- **AND** `--openfga-host` is not set
+- **THEN** the group is deleted from the database only (noop authorizer)
+
+#### Scenario: OpenFGA failure does not block DB cleanup
+- **WHEN** `import --sync` deletes a stale group from the DB but the authorizer call fails
+- **THEN** the failure is logged
+- **THEN** the overall sync continues for remaining groups
+
+### Requirement: Safe LIKE prefix matching
+The `ListGroupsByPrefix` storage method SHALL escape SQL LIKE wildcard characters (`%`, `_`, `\`) in the prefix argument before constructing the query, to prevent unintended group matches.
+
+#### Scenario: Prefix with no special characters
+- **WHEN** `ListGroupsByPrefix` is called with prefix `salesforce:`
+- **THEN** only groups whose names start with `salesforce:` are returned
+
+#### Scenario: Prefix with wildcard characters
+- **WHEN** `ListGroupsByPrefix` is called with a prefix containing `%` or `_`
+- **THEN** those characters are treated as literals, not wildcards
+
+### Requirement: Signal-aware context in CLI handlers
+All CLI command handlers SHALL use `cmd.Context()` for database and authorizer calls so that OS signals (SIGINT/SIGTERM) cancel in-flight operations.
+
+#### Scenario: SIGINT cancels operation
+- **WHEN** operator sends SIGINT while an `import --sync` operation is running
+- **THEN** the in-flight database call is cancelled
+
+### Requirement: Correct SPDX license identifiers
+All new Go source files in this change SHALL use `AGPL-3.0-only` as the SPDX identifier.
+
+#### Scenario: File header
+- **WHEN** a new file is added by this change
+- **THEN** line 2 reads `// SPDX-License-Identifier: AGPL-3.0-only`

--- a/openspec/changes/archive/2026-06-01-cli-user-group-sync/tasks.md
+++ b/openspec/changes/archive/2026-06-01-cli-user-group-sync/tasks.md
@@ -1,0 +1,55 @@
+## 1. Storage Layer
+
+- [x] 1.1 Add `RemoveUserFromAllGroups` to `internal/storage/groups.go`
+- [x] 1.2 Add `ListGroupsByPrefix` to `internal/storage/groups.go`
+- [x] 1.3 Add `SyncGroupMembers` to `internal/storage/groups.go`
+- [x] 1.4 Extend `StorageInterface` in `internal/storage/interfaces.go` with the three new methods
+- [x] 1.5 Escape LIKE wildcards (`%`, `_`, `\`) in `ListGroupsByPrefix` before constructing the query (add PostgreSQL `ESCAPE '\'` clause)
+
+## 2. Importer — Sync
+
+- [x] 2.1 Add `AuthorizerInterface` (single method: `DeleteGroup`) to `internal/importer/interfaces.go`
+- [x] 2.2 Add `authz AuthorizerInterface` field to `Importer`; update `NewImporter` signature
+- [x] 2.3 Implement `Importer.Sync()` — create/sync/delete loop over driver-prefixed groups
+- [x] 2.4 Call `authz.DeleteGroup` after `storage.DeleteGroup` in the stale-group deletion loop
+- [x] 2.5 Track per-group failures in `Sync` and return a non-nil error at the end if any operation failed (currently always returns `nil`)
+- [x] 2.6 Add `mock_authorizer.go` for `AuthorizerInterface`
+- [x] 2.7 Update `TestImporterSync` table to include `*MockAuthorizerInterface` and add `authz.EXPECT().DeleteGroup` expectation for the "stale groups deleted" case
+
+## 3. CLI — `users` Command
+
+- [x] 3.1 Create `cmd/users.go` with `users delete`, `users list-groups`, `users set-groups` subcommands
+- [x] 3.2 Implement `newStorageFromCmd` helper (shared by `users` and `groups`)
+- [x] 3.3 Mark `--group` as required on `users set-groups` (currently optional; omitting it silently removes user from all groups)
+- [x] 3.4 Replace `context.Background()` with `cmd.Context()` in all three `users` handlers
+
+## 4. CLI — `groups` Command
+
+- [x] 4.1 Create `cmd/groups_cmd.go` with `groups add-users`, `groups remove-users`, `groups list-users` subcommands
+- [x] 4.2 Mark `--user` as required on `groups add-users` (currently optional; omitting it is a silent no-op)
+- [x] 4.3 Replace `context.Background()` with `cmd.Context()` in all three `groups` handlers
+
+## 5. CLI — `import --sync`
+
+- [x] 5.1 Add `--sync` flag to `importCmd`
+- [x] 5.2 Add `--openfga-host`, `--openfga-store-id`, `--openfga-token`, `--openfga-model-id` flags to `importCmd`
+- [x] 5.3 Implement `buildAuthorizer` in `cmd/import.go` (noop when `--openfga-host` is empty)
+- [x] 5.4 Pass authorizer to `NewImporter` in `runImport`
+- [x] 5.5 Replace `context.Background()` with `cmd.Context()` in `runImport`
+
+## 6. Correctness Fixes
+
+- [x] 6.1 Fix SPDX identifier in `cmd/groups_cmd.go`: `AGPL-3.0` → `AGPL-3.0-only`
+- [x] 6.2 Fix SPDX identifier in `cmd/users.go`: `AGPL-3.0` → `AGPL-3.0-only`
+- [x] 6.3 Fix SPDX identifier in `cmd/groups_cmd_test.go`: `AGPL-3.0` → `AGPL-3.0-only`
+- [x] 6.4 Fix SPDX identifier in `cmd/users_test.go`: `AGPL-3.0` → `AGPL-3.0-only`
+
+## 7. Tests
+
+- [x] 7.1 `TestImporterRun` unit tests exist and pass
+- [x] 7.2 `TestImporterSync` unit tests exist and pass (including partial-failure cases)
+- [x] 7.3 Integration tests `TestImporterRunIntegration` and `TestImporterSyncIntegration` exist
+- [x] 7.4 Add test for `Sync` partial-failure return value once task 2.5 is implemented
+- [x] 7.5 Add test cases for `--user` required validation (task 4.2) and `--group` required validation (task 3.3)
+- [x] 7.6 `TestGroupsAddUsersRequiresDSN`, `TestGroupsRemoveUsersRequiresDSN`, `TestGroupsListUsersRequiresDSN` exist
+- [x] 7.7 `TestUsersDeleteRequiresDSN`, `TestUsersListGroupsRequiresDSN`, `TestUsersSetGroupsRequiresDSN` exist

--- a/openspec/config.yaml
+++ b/openspec/config.yaml
@@ -1,0 +1,30 @@
+schema: spec-driven
+
+context: |
+  hook-service is a Go OAuth token-hook service.
+  Integrations: Ory Kratos, Ory Hydra, OpenFGA, optional Salesforce.
+  Stack: Go, PostgreSQL, gRPC/gRPC-gateway, cobra CLI, OpenTelemetry.
+
+  OpenSpec intent for this repo:
+  - Specs are the single source of truth for behavior.
+  - Purpose captures concise rationale (why); Requirements capture normative behavior (what).
+  - Keep artifact prose human-readable and avoid dumping implementation details into canonical specs.
+
+  Authoritative code conventions live in .github/copilot-instructions.md; do not duplicate them here.
+
+rules:
+  spec:
+    - Every capability spec under openspec/specs/ must include a ## Purpose section before ## Requirements
+    - The ## Purpose section is the single source of truth for design rationale (ADR-style); capture intent, goals, non-goals, and key decisions (with brief alternatives) so no separate ADR or design file is needed
+    - Keep the ## Purpose human-readable: prose and decisions, not machine-generated task lists or file-path dumps
+    - If Purpose includes a Non-goals subsection, each item must be capability-specific and describe concrete out-of-scope boundaries (avoid repeated boilerplate across specs)
+    - Requirements stay behaviour-driven (SHALL/MUST + #### Scenario blocks); the "why" lives in ## Purpose, the "what" in ## Requirements
+    - Exclude repository coding conventions from capability requirements (for example, SPDX headers, formatting, lint style, or file scaffolding rules); keep those in repository instructions/tooling
+  proposal:
+    - Keep proposals concise (under 400 words)
+    - Always include a Non-goals section
+    - Reference affected packages by name
+  tasks:
+    - Break tasks into single-package units of work
+    - Each task must reference the file(s) it touches
+    - Always include a task for updating/adding tests

--- a/openspec/specs/cli-group-management/spec.md
+++ b/openspec/specs/cli-group-management/spec.md
@@ -1,0 +1,74 @@
+## Purpose
+
+Directly manage group memberships from the CLI so operators can add, remove, and inspect members without calling service APIs.
+
+This capability exists to support day-to-day operational administration and incident remediation from scripts or terminals. It prioritizes predictable command outcomes and machine-readable output so membership changes can be automated safely.
+
+Key decisions:
+- Membership mutation commands are explicit per group (`add-users`, `remove-users`) to reduce accidental blast radius.
+- Removal is idempotent so repeated cleanup commands remain safe.
+- Commands support structured output (`--format json`) for automation and integration.
+
+Non-goals:
+- This spec does not define user-wide reconciliation across all groups (`users set-groups/delete/list-groups`).
+- This spec does not define driver-based import/reconciliation (`import --sync`) or prefix-scoped cleanup behavior.
+- This spec does not define group lifecycle management (create/delete groups).
+
+## Requirements
+
+### Requirement: Add users to a group
+The CLI SHALL provide a `groups add-users <group-id>` subcommand that adds the specified users to a group. The `--user` flag SHALL be required and repeatable.
+
+#### Scenario: Users added
+- **WHEN** operator runs `groups add-users <group-id> --user <id1> --user <id2> --dsn <dsn>`
+- **THEN** the specified users are members of the group
+- **THEN** the command exits with code 0
+
+#### Scenario: Missing --user flag
+- **WHEN** operator runs `groups add-users <group-id> --dsn <dsn>` without any `--user` flag
+- **THEN** the command exits with a non-zero code and an error message
+
+#### Scenario: JSON output
+- **WHEN** operator runs `groups add-users <group-id> --user <id1> --dsn <dsn> --format json`
+- **THEN** the command outputs `{"group_id": "<group-id>", "users_added": 1}` as valid JSON
+
+### Requirement: Remove users from a group
+The CLI SHALL provide a `groups remove-users <group-id>` subcommand that removes the specified users from a group. The operation SHALL be idempotent.
+
+#### Scenario: Users removed
+- **WHEN** operator runs `groups remove-users <group-id> --user <id1> --dsn <dsn>`
+- **THEN** the specified users are no longer members of the group
+
+#### Scenario: User not in group
+- **WHEN** operator runs `groups remove-users <group-id> --user <id1> --dsn <dsn>` for a user not in the group
+- **THEN** the command exits with code 0 (idempotent)
+
+#### Scenario: JSON output
+- **WHEN** operator runs `groups remove-users <group-id> --user <id1> --dsn <dsn> --format json`
+- **THEN** the command outputs `{"group_id": "<group-id>", "users_removed": 1}` as valid JSON
+
+### Requirement: List users in a group
+The CLI SHALL provide a `groups list-users <group-id>` subcommand that prints all members of the specified group.
+
+#### Scenario: Group has members
+- **WHEN** operator runs `groups list-users <group-id> --dsn <dsn>`
+- **THEN** each user ID is printed on a separate line
+
+#### Scenario: Group has no members
+- **WHEN** operator runs `groups list-users <group-id> --dsn <dsn>` for an empty group
+- **THEN** the command exits with code 0 and prints nothing
+
+#### Scenario: JSON output
+- **WHEN** operator runs `groups list-users <group-id> --dsn <dsn> --format json`
+- **THEN** the command outputs a JSON array of user ID strings (empty array when no members)
+
+### Requirement: Exactly one positional argument required
+All `groups` subcommands SHALL require exactly one positional argument (the group ID).
+
+#### Scenario: No positional argument
+- **WHEN** operator runs a `groups` subcommand with no positional argument
+- **THEN** the command exits with a non-zero code
+
+#### Scenario: Extra positional argument
+- **WHEN** operator runs a `groups` subcommand with two positional arguments
+- **THEN** the command exits with a non-zero code

--- a/openspec/specs/cli-user-management/spec.md
+++ b/openspec/specs/cli-user-management/spec.md
@@ -1,0 +1,78 @@
+## Purpose
+
+Provide operator-facing CLI commands to inspect and reconcile a user's memberships across groups without requiring service API calls.
+
+This capability exists to support safe operational maintenance and incident response from the command line. It prioritizes deterministic outcomes and scriptability so operators can run cleanup and reconciliation commands repeatedly with predictable results.
+
+Key decisions:
+- User-level destructive cleanup is idempotent (`users delete` succeeds even when no memberships exist).
+- Commands support machine-readable output (`--format json`) for automation workflows.
+- Guardrails prevent accidental broad changes (`users set-groups` requires at least one `--group`).
+
+Non-goals:
+- This spec does not define group-level membership commands (`groups add-users/remove-users/list-users`).
+- This spec does not define external identity/group import or reconciliation behavior (`import --sync`).
+- This spec does not define authorization-policy tuple management outside direct user-membership CLI actions.
+
+## Requirements
+
+### Requirement: Delete user from all groups
+The CLI SHALL provide a `users delete <user-id>` subcommand that removes the specified user from every group they belong to. The operation SHALL be idempotent — it succeeds even when the user has no memberships.
+
+#### Scenario: User deleted from all groups
+- **WHEN** operator runs `users delete <user-id> --dsn <dsn>`
+- **THEN** the user is removed from all groups in the database
+- **THEN** the command exits with code 0 and prints a confirmation message
+
+#### Scenario: User has no memberships
+- **WHEN** operator runs `users delete <user-id> --dsn <dsn>` for a user with no group memberships
+- **THEN** the command exits with code 0 (idempotent)
+
+#### Scenario: JSON output
+- **WHEN** operator runs `users delete <user-id> --dsn <dsn> --format json`
+- **THEN** the command outputs `{"user_id": "<user-id>", "status": "deleted"}` as valid JSON
+
+#### Scenario: Missing DSN
+- **WHEN** operator runs `users delete <user-id>` without `--dsn`
+- **THEN** the command exits with a non-zero code and an error message
+
+### Requirement: List groups for a user
+The CLI SHALL provide a `users list-groups <user-id>` subcommand that prints all groups the specified user belongs to.
+
+#### Scenario: User is in groups
+- **WHEN** operator runs `users list-groups <user-id> --dsn <dsn>`
+- **THEN** each group name is printed on a separate line
+
+#### Scenario: User is in no groups
+- **WHEN** operator runs `users list-groups <user-id> --dsn <dsn>` for a user with no memberships
+- **THEN** the command exits with code 0 and prints nothing
+
+#### Scenario: JSON output
+- **WHEN** operator runs `users list-groups <user-id> --dsn <dsn> --format json`
+- **THEN** the command outputs a JSON array of group objects (empty array when no memberships)
+
+### Requirement: Set groups for a user
+The CLI SHALL provide a `users set-groups <user-id>` subcommand that replaces the user's group memberships with the provided set. The `--group` flag SHALL be required to prevent accidental removal of all memberships.
+
+#### Scenario: Groups replaced
+- **WHEN** operator runs `users set-groups <user-id> --group <id1> --group <id2> --dsn <dsn>`
+- **THEN** the user belongs exactly to the specified groups
+
+#### Scenario: Missing --group flag
+- **WHEN** operator runs `users set-groups <user-id> --dsn <dsn>` without any `--group` flag
+- **THEN** the command exits with a non-zero code and an error message
+
+#### Scenario: Context cancellation
+- **WHEN** operator sends SIGINT while `users set-groups` is running
+- **THEN** the in-flight database operation is cancelled and the command exits with a non-zero code
+
+### Requirement: Exactly one positional argument required
+All `users` subcommands SHALL require exactly one positional argument (the user ID). Too few or too many arguments SHALL result in a non-zero exit code.
+
+#### Scenario: No positional argument
+- **WHEN** operator runs a `users` subcommand with no positional argument
+- **THEN** the command exits with a non-zero code
+
+#### Scenario: Extra positional argument
+- **WHEN** operator runs a `users` subcommand with two positional arguments
+- **THEN** the command exits with a non-zero code

--- a/openspec/specs/import-sync/spec.md
+++ b/openspec/specs/import-sync/spec.md
@@ -1,0 +1,95 @@
+## Purpose
+
+Reconcile imported external-group state with database state so stale driver-managed groups and memberships are cleaned up safely and consistently.
+
+This capability exists because imported identity/group data drifts over time if sync remains additive-only. The sync mode ensures the database and authorization state converge on the external source of truth without affecting unrelated local groups.
+
+Key decisions:
+- Reconciliation is opt-in via `--sync` and keeps additive import as the default behavior.
+- Destructive cleanup is prefix-scoped so only driver-managed groups are eligible for deletion.
+- OpenFGA tuple cleanup is coupled to stale-group deletion when OpenFGA is configured.
+- Per-group failures are aggregated: processing continues, but exit status is non-zero.
+
+Non-goals:
+- This spec does not define reconciliation semantics for non-driver-managed local groups (groups outside the driver prefix).
+- This spec does not require all group operations in a sync run to be atomic as a single global transaction.
+- This spec does not define manual CLI membership operations (`users/*`, `groups/*`) outside import execution.
+
+## Requirements
+
+### Requirement: Reconcile database with driver data
+The `import` command SHALL accept a `--sync` flag that, when present, reconciles the database against the current state of the external driver instead of performing an additive-only import. Reconciliation MUST:
+- Create groups present in the driver but absent from the database
+- Sync memberships for groups present in both the driver and the database
+- Delete groups present in the database but absent from the driver (only those matching the driver's prefix)
+- Never modify groups that do not match the driver's prefix
+
+#### Scenario: New groups created
+- **WHEN** operator runs `import --sync --driver salesforce ...`
+- **AND** the driver returns a group that does not exist in the database
+- **THEN** the group and its members are created in the database
+
+#### Scenario: Existing group memberships reconciled
+- **WHEN** operator runs `import --sync --driver salesforce ...`
+- **AND** the driver returns a group that already exists in the database with different members
+- **THEN** the group's members are updated to exactly match the driver's list
+
+#### Scenario: Stale groups deleted
+- **WHEN** operator runs `import --sync --driver salesforce ...`
+- **AND** the database contains a prefixed group that is absent from the driver data
+- **THEN** the group is deleted from the database
+- **THEN** all OpenFGA authorization tuples for the deleted group are removed
+
+#### Scenario: Non-prefixed groups untouched
+- **WHEN** operator runs `import --sync --driver salesforce ...`
+- **AND** the database contains a group whose name does not start with `salesforce:`
+- **THEN** that group is not modified or deleted
+
+### Requirement: Partial failure reporting
+If one or more per-group operations fail during `--sync`, the `import` command SHALL exit with a non-zero exit code after completing all remaining operations. Individual failures SHALL be logged.
+
+#### Scenario: One group fails, others succeed
+- **WHEN** `import --sync` encounters a DB error for one group
+- **THEN** reconciliation continues for the remaining groups
+- **THEN** the command exits with a non-zero exit code
+
+#### Scenario: All groups succeed
+- **WHEN** `import --sync` completes all operations without error
+- **THEN** the command exits with code 0
+
+### Requirement: OpenFGA tuple cleanup on group deletion
+When `import --sync` deletes a stale group, it SHALL also remove all associated OpenFGA authorization tuples (via the authorizer). If `--openfga-host` is not provided, the cleanup step is skipped (noop authorizer).
+
+#### Scenario: Stale group deleted with OpenFGA configured
+- **WHEN** `import --sync` deletes a stale group
+- **AND** `--openfga-host` is set
+- **THEN** all OpenFGA tuples for that group are removed after the DB delete
+
+#### Scenario: Stale group deleted without OpenFGA configured
+- **WHEN** `import --sync` deletes a stale group
+- **AND** `--openfga-host` is not set
+- **THEN** the group is deleted from the database only (noop authorizer)
+
+#### Scenario: OpenFGA failure does not block DB cleanup
+- **WHEN** `import --sync` deletes a stale group from the DB but the authorizer call fails
+- **THEN** the failure is logged
+- **THEN** the overall sync continues for remaining groups
+
+### Requirement: Safe LIKE prefix matching
+The `ListGroupsByPrefix` storage method SHALL escape SQL LIKE wildcard characters (`%`, `_`, `\`) in the prefix argument before constructing the query, to prevent unintended group matches.
+
+#### Scenario: Prefix with no special characters
+- **WHEN** `ListGroupsByPrefix` is called with prefix `salesforce:`
+- **THEN** only groups whose names start with `salesforce:` are returned
+
+#### Scenario: Prefix with wildcard characters
+- **WHEN** `ListGroupsByPrefix` is called with a prefix containing `%` or `_`
+- **THEN** those characters are treated as literals, not wildcards
+
+### Requirement: Signal-aware context in CLI handlers
+All CLI command handlers SHALL use `cmd.Context()` for database and authorizer calls so that OS signals (SIGINT/SIGTERM) cancel in-flight operations.
+
+#### Scenario: SIGINT cancels operation
+- **WHEN** operator sends SIGINT while an `import --sync` operation is running
+- **THEN** the in-flight database call is cancelled
+

--- a/pkg/groups/service.go
+++ b/pkg/groups/service.go
@@ -101,9 +101,6 @@ func (s *Service) AddUsersToGroup(ctx context.Context, groupID string, userIDs [
 	}
 
 	if err := s.db.AddUsersToGroup(ctx, groupID, userIDs); err != nil {
-		if errors.Is(err, storage.ErrDuplicateKey) {
-			return ErrUserAlreadyInGroup
-		}
 		if errors.Is(err, storage.ErrForeignKeyViolation) {
 			return ErrInvalidGroupID
 		}

--- a/pkg/groups/service_test.go
+++ b/pkg/groups/service_test.go
@@ -464,13 +464,6 @@ func TestService_AddUsersToGroup(t *testing.T) {
 			expectedErr: ErrInvalidGroupID,
 		},
 		{
-			name: "user already in group",
-			setupMocks: func(mockStorage *MockDatabaseInterface) {
-				mockStorage.EXPECT().AddUsersToGroup(gomock.Any(), groupID, userIDs).Return(storage.ErrDuplicateKey)
-			},
-			expectedErr: ErrUserAlreadyInGroup,
-		},
-		{
 			name: "db error",
 			setupMocks: func(mockStorage *MockDatabaseInterface) {
 				mockStorage.EXPECT().AddUsersToGroup(gomock.Any(), groupID, userIDs).Return(dbErr)


### PR DESCRIPTION
IAM-2012

- Enhance CLI commands
- Init openspec

Re openspec:
- To set it up:
  1. Ran `openspec init` (for copilot)
  3. Asked it to propose the plan for the feature (I had already half implemented it, using other prompts) using `/opsx-propose `
  4. Applied the task `/opsx-apply `
  5. Used a testing script (it is attached bellow) to validate the changes
  6. After everything was fixed I archived the changes with `/opsx-archive `
- I told the agent to fill in the openspec config.
- I decided not to commit the `changes` dir. 
- I committed the produced prompts/skills, but I'm not sure if I should

Used the following script to test the implementation (with salesforce creds for staging) https://pastebin.canonical.com/p/jhFbqnf3g7/


Closes #233 
